### PR TITLE
3.15.0

### DIFF
--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -1,5684 +1,5719 @@
 [
     {
-        "type": "git",
-        "url": "https://github.com/an-anime-team/anime-game-core",
-        "commit": "c51c37e53fc114258e40f09514e614a260854041",
-        "dest": "flatpak-cargo/git/anime-game-core-c51c37e"
-    },
-    {
-        "type": "git",
-        "url": "https://github.com/an-anime-team/anime-launcher-sdk",
-        "commit": "3bbc3a0857576707520d8a01eaef1712286340b8",
-        "dest": "flatpak-cargo/git/anime-launcher-sdk-3bbc3a0"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/addr2line/addr2line-0.24.2.crate",
         "sha256": "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1",
-        "dest": "cargo/vendor/addr2line-0.24.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "addr2line-0.24.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/addr2line-0.24.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/adler2/adler2-2.0.1.crate",
         "sha256": "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa",
-        "dest": "cargo/vendor/adler2-2.0.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "adler2-2.0.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/adler2-2.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/aes/aes-0.8.4.crate",
         "sha256": "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0",
-        "dest": "cargo/vendor/aes-0.8.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "aes-0.8.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/aes-0.8.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/ahash/ahash-0.8.12.crate",
         "sha256": "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75",
-        "dest": "cargo/vendor/ahash-0.8.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "ahash-0.8.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ahash-0.8.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.1.3.crate",
         "sha256": "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916",
-        "dest": "cargo/vendor/aho-corasick-1.1.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "aho-corasick-1.1.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/aho-corasick-1.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/allocator-api2/allocator-api2-0.2.21.crate",
         "sha256": "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923",
-        "dest": "cargo/vendor/allocator-api2-0.2.21"
+        "dest": "cargo/vendor",
+        "dest-filename": "allocator-api2-0.2.21.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/allocator-api2-0.2.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "shell",
-        "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/anime-game-core-c51c37e/.\" \"cargo/vendor/anime-game-core\""
-        ]
+        "type": "git",
+        "url": "https://github.com/an-anime-team/anime-game-core",
+        "commit": "0863d82ae5d60c82a457c9f219e0618e6cb9e921",
+        "dest": "cargo/vendor/anime-game-core"
     },
     {
-        "type": "inline",
-        "contents": "[package]\nname = \"anime-game-core\"\nversion = \"1.32.2\"\nauthors = [ \"Nikita Podvirnyi <krypt0nn@vk.com>\",]\nlicense = \"GPL-3.0\"\nreadme = \"README.md\"\nrepository = \"https://github.com/an-anime-team/anime-game-core\"\nedition = \"2021\"\n\n[dependencies]\ndns-lookup = \"2.0\"\nserde_json = \"1.0\"\nfs_extra = \"1.3.0\"\nthiserror = \"1.0\"\ntracing = \"0.1\"\nlazy_static = \"1.5.0\"\n\n[features]\ngenshin = []\nstar-rail = []\nzzz = []\nhonkai = []\npgr = []\nwuwa = [ \"dep:flate2\", \"dep:brotli-decompressor\",]\nsophon = [ \"dep:md-5\", \"dep:zstd\", \"dep:reqwest\", \"dep:protobuf\", \"dep:protobuf-codegen\",]\ninstall = [ \"external\", \"dep:sysinfo\", \"dep:zip\", \"dep:tar\", \"dep:xz\", \"dep:bzip2\", \"dep:flate2\", \"dep:md-5\",]\nexternal = [ \"dep:kinda-virtual-fs\",]\npatches = []\npatch-jadeite = []\npatch-mfc140 = []\nall = [ \"install\", \"external\", \"patches\", \"sophon\",]\n\n[dependencies.minreq]\nversion = \"2.13\"\nfeatures = [ \"json-using-serde\", \"https-rustls-probe\", \"proxy\",]\n\n[dependencies.serde]\nversion = \"1.0\"\nfeatures = [ \"derive\",]\n\n[dependencies.cached]\nversion = \"0.55\"\nfeatures = [ \"proc_macro\",]\n\n[dependencies.anyhow]\nversion = \"1.0\"\nfeatures = [ \"backtrace\",]\n\n[dependencies.sysinfo]\nversion = \"0.35\"\noptional = true\nfeatures = [ \"linux-netdevs\",]\n\n[dependencies.zip]\nversion = \"3.0\"\noptional = true\n\n[dependencies.tar]\nversion = \"0.4\"\noptional = true\n\n[dependencies.xz]\nversion = \"0.1\"\noptional = true\n\n[dependencies.bzip2]\nversion = \"0.4\"\noptional = true\n\n[dependencies.flate2]\nversion = \"1.0\"\noptional = true\n\n[dependencies.md-5]\nversion = \"0.10\"\nfeatures = [ \"asm\",]\noptional = true\n\n[dependencies.kinda-virtual-fs]\nversion = \"0.1.1\"\noptional = true\n\n[dependencies.brotli-decompressor]\nversion = \"4.0\"\noptional = true\n\n[dependencies.zstd]\nversion = \"0.13\"\noptional = true\n\n[dependencies.reqwest]\nversion = \"0.12\"\nfeatures = [ \"blocking\", \"h2\", \"http2\", \"json\", \"rustls-tls\", \"rustls-tls-webpki-roots\", \"socks\",]\ndefault-features = false\noptional = true\n\n[dependencies.protobuf]\nversion = \"3.7\"\noptional = true\n\n[build-dependencies.protobuf-codegen]\nversion = \"3.7.2\"\noptional = true\n",
-        "dest": "cargo/vendor/anime-game-core",
-        "dest-filename": "Cargo.toml"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": null, \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20null%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/anime-game-core",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "shell",
-        "commands": [
-            "cp -r --reflink=auto \"flatpak-cargo/git/anime-launcher-sdk-3bbc3a0/.\" \"cargo/vendor/anime-launcher-sdk\""
-        ]
+        "type": "git",
+        "url": "https://github.com/an-anime-team/anime-launcher-sdk",
+        "commit": "200e4bd0a499acadcd688c6c48507e9d3a61e627",
+        "dest": "cargo/vendor/anime-launcher-sdk"
     },
     {
-        "type": "inline",
-        "contents": "[package]\nname = \"anime-launcher-sdk\"\nversion = \"1.28.7\"\nauthors = [ \"Nikita Podvirnyi <krypt0nn@vk.com>\",]\nlicense = \"GPL-3.0\"\nreadme = \"README.md\"\nrepository = \"https://github.com/an-anime-team/anime-launcher-sdk\"\nedition = \"2021\"\n\n[dependencies]\ntracing = \"0.1\"\n\n[features]\ngenshin = [ \"anime-game-core/genshin\", \"anime-game-core/sophon\",]\nstar-rail = [ \"anime-game-core/star-rail\",]\nzzz = [ \"anime-game-core/zzz\",]\nhonkai = [ \"anime-game-core/honkai\",]\npgr = [ \"anime-game-core/pgr\",]\nwuwa = [ \"anime-game-core/wuwa\",]\nstar-rail-patch = [ \"anime-game-core/patch-jadeite\",]\nhonkai-patch = [ \"anime-game-core/patch-jadeite\",]\npgr-patch = [ \"anime-game-core/patch-mfc140\",]\nwuwa-patch = [ \"anime-game-core/patch-jadeite\",]\nstates = []\nconfig = [ \"dep:serde\", \"dep:serde_json\", \"dep:enum-ordinalize\",]\ncomponents = [ \"dep:wincompatlib\", \"dep:lazy_static\",]\ngame = [ \"components\", \"config\",]\nsandbox = []\nsessions = []\nenvironment-emulation = []\nfps-unlocker = [ \"dep:md-5\",]\nall = [ \"states\", \"config\", \"components\", \"game\", \"sandbox\", \"sessions\", \"environment-emulation\", \"fps-unlocker\",]\ndefault = [ \"all\",]\n\n[dependencies.anime-game-core]\ngit = \"https://github.com/an-anime-team/anime-game-core\"\ntag = \"1.32.2\"\nfeatures = [ \"all\",]\n\n[dependencies.anyhow]\nversion = \"1.0\"\nfeatures = [ \"backtrace\",]\n\n[dependencies.serde]\nversion = \"1.0\"\nfeatures = [ \"derive\",]\noptional = true\n\n[dependencies.serde_json]\nversion = \"1.0\"\noptional = true\n\n[dependencies.cached]\nversion = \"0.55\"\nfeatures = [ \"proc_macro\",]\n\n[dependencies.enum-ordinalize]\nversion = \"4.3\"\noptional = true\n\n[dependencies.wincompatlib]\nversion = \"0.7.7\"\nfeatures = [ \"all\",]\noptional = true\n\n[dependencies.lazy_static]\nversion = \"1.5.0\"\noptional = true\n\n[dependencies.md-5]\nversion = \"0.10\"\nfeatures = [ \"asm\",]\noptional = true\n",
-        "dest": "cargo/vendor/anime-launcher-sdk",
-        "dest-filename": "Cargo.toml"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": null, \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20null%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/anime-launcher-sdk",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/anstream/anstream-0.6.19.crate",
         "sha256": "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933",
-        "dest": "cargo/vendor/anstream-0.6.19"
+        "dest": "cargo/vendor",
+        "dest-filename": "anstream-0.6.19.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/anstream-0.6.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/anstyle/anstyle-1.0.11.crate",
         "sha256": "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd",
-        "dest": "cargo/vendor/anstyle-1.0.11"
+        "dest": "cargo/vendor",
+        "dest-filename": "anstyle-1.0.11.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/anstyle-1.0.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/anstyle-parse/anstyle-parse-0.2.7.crate",
         "sha256": "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2",
-        "dest": "cargo/vendor/anstyle-parse-0.2.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "anstyle-parse-0.2.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/anstyle-parse-0.2.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/anstyle-query/anstyle-query-1.1.3.crate",
         "sha256": "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9",
-        "dest": "cargo/vendor/anstyle-query-1.1.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "anstyle-query-1.1.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/anstyle-query-1.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/anstyle-wincon/anstyle-wincon-3.0.9.crate",
         "sha256": "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882",
-        "dest": "cargo/vendor/anstyle-wincon-3.0.9"
+        "dest": "cargo/vendor",
+        "dest-filename": "anstyle-wincon-3.0.9.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/anstyle-wincon-3.0.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.98.crate",
         "sha256": "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487",
-        "dest": "cargo/vendor/anyhow-1.0.98"
+        "dest": "cargo/vendor",
+        "dest-filename": "anyhow-1.0.98.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/anyhow-1.0.98",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/arbitrary/arbitrary-1.4.1.crate",
         "sha256": "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223",
-        "dest": "cargo/vendor/arbitrary-1.4.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "arbitrary-1.4.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/arbitrary-1.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/arrayref/arrayref-0.3.9.crate",
         "sha256": "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb",
-        "dest": "cargo/vendor/arrayref-0.3.9"
+        "dest": "cargo/vendor",
+        "dest-filename": "arrayref-0.3.9.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2276a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/arrayref-0.3.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.6.crate",
         "sha256": "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50",
-        "dest": "cargo/vendor/arrayvec-0.7.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "arrayvec-0.7.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/arrayvec-0.7.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/ashpd/ashpd-0.11.0.crate",
         "sha256": "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df",
-        "dest": "cargo/vendor/ashpd-0.11.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "ashpd-0.11.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ashpd-0.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/async-broadcast/async-broadcast-0.7.2.crate",
         "sha256": "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532",
-        "dest": "cargo/vendor/async-broadcast-0.7.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "async-broadcast-0.7.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/async-broadcast-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/async-recursion/async-recursion-1.1.1.crate",
         "sha256": "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11",
-        "dest": "cargo/vendor/async-recursion-1.1.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "async-recursion-1.1.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/async-recursion-1.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.88.crate",
         "sha256": "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5",
-        "dest": "cargo/vendor/async-trait-0.1.88"
+        "dest": "cargo/vendor",
+        "dest-filename": "async-trait-0.1.88.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/async-trait-0.1.88",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/atomic-waker/atomic-waker-1.1.2.crate",
         "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
-        "dest": "cargo/vendor/atomic-waker-1.1.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "atomic-waker-1.1.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/atomic-waker-1.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/autocfg/autocfg-1.5.0.crate",
         "sha256": "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8",
-        "dest": "cargo/vendor/autocfg-1.5.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "autocfg-1.5.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/autocfg-1.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/backtrace/backtrace-0.3.75.crate",
         "sha256": "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002",
-        "dest": "cargo/vendor/backtrace-0.3.75"
+        "dest": "cargo/vendor",
+        "dest-filename": "backtrace-0.3.75.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/backtrace-0.3.75",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/base64/base64-0.21.7.crate",
         "sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567",
-        "dest": "cargo/vendor/base64-0.21.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "base64-0.21.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/base64-0.21.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/base64/base64-0.22.1.crate",
         "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
-        "dest": "cargo/vendor/base64-0.22.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "base64-0.22.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2272b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/base64-0.22.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/bitflags/bitflags-2.9.1.crate",
         "sha256": "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967",
-        "dest": "cargo/vendor/bitflags-2.9.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "bitflags-2.9.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/bitflags-2.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/blake3/blake3-1.8.2.crate",
         "sha256": "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0",
-        "dest": "cargo/vendor/blake3-1.8.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "blake3-1.8.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/blake3-1.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/block-buffer/block-buffer-0.10.4.crate",
         "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71",
-        "dest": "cargo/vendor/block-buffer-0.10.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "block-buffer-0.10.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/block-buffer-0.10.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/block2/block2-0.6.1.crate",
         "sha256": "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2",
-        "dest": "cargo/vendor/block2-0.6.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "block2-0.6.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/block2-0.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/bstr/bstr-1.12.0.crate",
         "sha256": "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4",
-        "dest": "cargo/vendor/bstr-1.12.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "bstr-1.12.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/bstr-1.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.18.1.crate",
-        "sha256": "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee",
-        "dest": "cargo/vendor/bumpalo-3.18.1"
+        "type": "file",
+        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.19.0.crate",
+        "sha256": "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43",
+        "dest": "cargo/vendor",
+        "dest-filename": "bumpalo-3.19.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee\", \"files\": {}}",
-        "dest": "cargo/vendor/bumpalo-3.18.1",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2246c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/bumpalo-3.19.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/byteorder/byteorder-1.5.0.crate",
         "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
-        "dest": "cargo/vendor/byteorder-1.5.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "byteorder-1.5.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/byteorder-1.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/bytes/bytes-1.10.1.crate",
         "sha256": "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a",
-        "dest": "cargo/vendor/bytes-1.10.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "bytes-1.10.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/bytes-1.10.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/bzip2/bzip2-0.4.4.crate",
         "sha256": "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8",
-        "dest": "cargo/vendor/bzip2-0.4.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "bzip2-0.4.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/bzip2-0.4.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/bzip2/bzip2-0.5.2.crate",
         "sha256": "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47",
-        "dest": "cargo/vendor/bzip2-0.5.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "bzip2-0.5.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2249ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/bzip2-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/bzip2-sys/bzip2-sys-0.1.13+1.0.8.crate",
         "sha256": "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14",
-        "dest": "cargo/vendor/bzip2-sys-0.1.13+1.0.8"
+        "dest": "cargo/vendor",
+        "dest-filename": "bzip2-sys-0.1.13+1.0.8.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/bzip2-sys-0.1.13+1.0.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/cached/cached-0.55.1.crate",
         "sha256": "b0839c297f8783316fcca9d90344424e968395413f0662a5481f79c6648bbc14",
-        "dest": "cargo/vendor/cached-0.55.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "cached-0.55.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b0839c297f8783316fcca9d90344424e968395413f0662a5481f79c6648bbc14\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b0839c297f8783316fcca9d90344424e968395413f0662a5481f79c6648bbc14%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/cached-0.55.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/cached_proc_macro/cached_proc_macro-0.24.0.crate",
         "sha256": "673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603",
-        "dest": "cargo/vendor/cached_proc_macro-0.24.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "cached_proc_macro-0.24.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22673992d934f0711b68ebb3e1b79cdc4be31634b37c98f26867ced0438ca5c603%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/cached_proc_macro-0.24.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/cached_proc_macro_types/cached_proc_macro_types-0.1.1.crate",
         "sha256": "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0",
-        "dest": "cargo/vendor/cached_proc_macro_types-0.1.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "cached_proc_macro_types-0.1.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/cached_proc_macro_types-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.20.12.crate",
         "sha256": "91e3bd0f4e25afa9cabc157908d14eeef9067d6448c49414d17b3fb55f0eadd0",
-        "dest": "cargo/vendor/cairo-rs-0.20.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "cairo-rs-0.20.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"91e3bd0f4e25afa9cabc157908d14eeef9067d6448c49414d17b3fb55f0eadd0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2291e3bd0f4e25afa9cabc157908d14eeef9067d6448c49414d17b3fb55f0eadd0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/cairo-rs-0.20.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.20.10.crate",
         "sha256": "059cc746549898cbfd9a47754288e5a958756650ef4652bbb6c5f71a6bda4f8b",
-        "dest": "cargo/vendor/cairo-sys-rs-0.20.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "cairo-sys-rs-0.20.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"059cc746549898cbfd9a47754288e5a958756650ef4652bbb6c5f71a6bda4f8b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22059cc746549898cbfd9a47754288e5a958756650ef4652bbb6c5f71a6bda4f8b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/cairo-sys-rs-0.20.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.2.27.crate",
-        "sha256": "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc",
-        "dest": "cargo/vendor/cc-1.2.27"
+        "type": "file",
+        "url": "https://static.crates.io/crates/cc/cc-1.2.29.crate",
+        "sha256": "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362",
+        "dest": "cargo/vendor",
+        "dest-filename": "cc-1.2.29.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.2.27",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/cc-1.2.29",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.20.0.crate",
-        "sha256": "e34e221e91c7eb5e8315b5c9cf1a61670938c0626451f954a51693ed44b37f45",
-        "dest": "cargo/vendor/cfg-expr-0.20.0"
+        "type": "file",
+        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.20.1.crate",
+        "sha256": "0d0390889d58f934f01cd49736275b4c2da15bcfc328c78ff2349907e6cabf22",
+        "dest": "cargo/vendor",
+        "dest-filename": "cfg-expr-0.20.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e34e221e91c7eb5e8315b5c9cf1a61670938c0626451f954a51693ed44b37f45\", \"files\": {}}",
-        "dest": "cargo/vendor/cfg-expr-0.20.0",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220d0390889d58f934f01cd49736275b4c2da15bcfc328c78ff2349907e6cabf22%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/cfg-expr-0.20.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.1.crate",
         "sha256": "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268",
-        "dest": "cargo/vendor/cfg-if-1.0.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "cfg-if-1.0.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/cfg-if-1.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.2.1.crate",
         "sha256": "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724",
-        "dest": "cargo/vendor/cfg_aliases-0.2.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "cfg_aliases-0.2.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/cfg_aliases-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/cipher/cipher-0.4.4.crate",
         "sha256": "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad",
-        "dest": "cargo/vendor/cipher-0.4.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "cipher-0.4.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/cipher-0.4.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/colorchoice/colorchoice-1.0.4.crate",
         "sha256": "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75",
-        "dest": "cargo/vendor/colorchoice-1.0.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "colorchoice-1.0.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/colorchoice-1.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/concurrent-queue/concurrent-queue-2.5.0.crate",
         "sha256": "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973",
-        "dest": "cargo/vendor/concurrent-queue-2.5.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "concurrent-queue-2.5.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/concurrent-queue-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/constant_time_eq/constant_time_eq-0.3.1.crate",
         "sha256": "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6",
-        "dest": "cargo/vendor/constant_time_eq-0.3.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "constant_time_eq-0.3.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/constant_time_eq-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.9.4.crate",
         "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f",
-        "dest": "cargo/vendor/core-foundation-0.9.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "core-foundation-0.9.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2291e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/core-foundation-0.9.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.7.crate",
         "sha256": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b",
-        "dest": "cargo/vendor/core-foundation-sys-0.8.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "core-foundation-sys-0.8.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/core-foundation-sys-0.8.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.17.crate",
         "sha256": "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280",
-        "dest": "cargo/vendor/cpufeatures-0.2.17"
+        "dest": "cargo/vendor",
+        "dest-filename": "cpufeatures-0.2.17.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2259ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/cpufeatures-0.2.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/crc/crc-3.3.0.crate",
         "sha256": "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675",
-        "dest": "cargo/vendor/crc-3.3.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "crc-3.3.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/crc-3.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/crc-catalog/crc-catalog-2.4.0.crate",
         "sha256": "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5",
-        "dest": "cargo/vendor/crc-catalog-2.4.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "crc-catalog-2.4.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2219d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/crc-catalog-2.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.4.2.crate",
         "sha256": "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3",
-        "dest": "cargo/vendor/crc32fast-1.4.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "crc32fast-1.4.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/crc32fast-1.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.8.6.crate",
         "sha256": "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51",
-        "dest": "cargo/vendor/crossbeam-deque-0.8.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "crossbeam-deque-0.8.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/crossbeam-deque-0.8.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.9.18.crate",
         "sha256": "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e",
-        "dest": "cargo/vendor/crossbeam-epoch-0.9.18"
+        "dest": "cargo/vendor",
+        "dest-filename": "crossbeam-epoch-0.9.18.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/crossbeam-epoch-0.9.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.21.crate",
         "sha256": "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28",
-        "dest": "cargo/vendor/crossbeam-utils-0.8.21"
+        "dest": "cargo/vendor",
+        "dest-filename": "crossbeam-utils-0.8.21.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/crossbeam-utils-0.8.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/crypto-common/crypto-common-0.1.6.crate",
         "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3",
-        "dest": "cargo/vendor/crypto-common-0.1.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "crypto-common-0.1.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/crypto-common-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/darling/darling-0.20.11.crate",
         "sha256": "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee",
-        "dest": "cargo/vendor/darling-0.20.11"
+        "dest": "cargo/vendor",
+        "dest-filename": "darling-0.20.11.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/darling-0.20.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/darling_core/darling_core-0.20.11.crate",
         "sha256": "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e",
-        "dest": "cargo/vendor/darling_core-0.20.11"
+        "dest": "cargo/vendor",
+        "dest-filename": "darling_core-0.20.11.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/darling_core-0.20.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/darling_macro/darling_macro-0.20.11.crate",
         "sha256": "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead",
-        "dest": "cargo/vendor/darling_macro-0.20.11"
+        "dest": "cargo/vendor",
+        "dest-filename": "darling_macro-0.20.11.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/darling_macro-0.20.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/deflate64/deflate64-0.1.9.crate",
         "sha256": "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b",
-        "dest": "cargo/vendor/deflate64-0.1.9"
+        "dest": "cargo/vendor",
+        "dest-filename": "deflate64-0.1.9.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/deflate64-0.1.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/deranged/deranged-0.4.0.crate",
         "sha256": "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e",
-        "dest": "cargo/vendor/deranged-0.4.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "deranged-0.4.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/deranged-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/derive_arbitrary/derive_arbitrary-1.4.1.crate",
         "sha256": "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800",
-        "dest": "cargo/vendor/derive_arbitrary-1.4.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "derive_arbitrary-1.4.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2230542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/derive_arbitrary-1.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/digest/digest-0.10.7.crate",
         "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
-        "dest": "cargo/vendor/digest-0.10.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "digest-0.10.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/digest-0.10.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/dispatch2/dispatch2-0.2.0.crate",
         "sha256": "1a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0",
-        "dest": "cargo/vendor/dispatch2-0.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "dispatch2-0.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/dispatch2-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/dispatch2/dispatch2-0.3.0.crate",
         "sha256": "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec",
-        "dest": "cargo/vendor/dispatch2-0.3.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "dispatch2-0.3.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2289a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/dispatch2-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/displaydoc/displaydoc-0.2.5.crate",
         "sha256": "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0",
-        "dest": "cargo/vendor/displaydoc-0.2.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "displaydoc-0.2.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2297369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/displaydoc-0.2.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/dns-lookup/dns-lookup-2.0.4.crate",
         "sha256": "e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc",
-        "dest": "cargo/vendor/dns-lookup-2.0.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "dns-lookup-2.0.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/dns-lookup-2.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/either/either-1.15.0.crate",
         "sha256": "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719",
-        "dest": "cargo/vendor/either-1.15.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "either-1.15.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2248c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/either-1.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/endi/endi-1.1.0.crate",
         "sha256": "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf",
-        "dest": "cargo/vendor/endi-1.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "endi-1.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/endi-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/enum-ordinalize/enum-ordinalize-4.3.0.crate",
         "sha256": "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5",
-        "dest": "cargo/vendor/enum-ordinalize-4.3.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "enum-ordinalize-4.3.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/enum-ordinalize-4.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/enum-ordinalize-derive/enum-ordinalize-derive-4.3.1.crate",
         "sha256": "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff",
-        "dest": "cargo/vendor/enum-ordinalize-derive-4.3.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "enum-ordinalize-derive-4.3.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/enum-ordinalize-derive-4.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/enumflags2/enumflags2-0.7.12.crate",
         "sha256": "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef",
-        "dest": "cargo/vendor/enumflags2-0.7.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "enumflags2-0.7.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/enumflags2-0.7.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.7.12.crate",
         "sha256": "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827",
-        "dest": "cargo/vendor/enumflags2_derive-0.7.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "enumflags2_derive-0.7.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2267c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/enumflags2_derive-0.7.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/equivalent/equivalent-1.0.2.crate",
         "sha256": "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f",
-        "dest": "cargo/vendor/equivalent-1.0.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "equivalent-1.0.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/equivalent-1.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/errno/errno-0.3.13.crate",
         "sha256": "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad",
-        "dest": "cargo/vendor/errno-0.3.13"
+        "dest": "cargo/vendor",
+        "dest-filename": "errno-0.3.13.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/errno-0.3.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/event-listener/event-listener-5.4.0.crate",
         "sha256": "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae",
-        "dest": "cargo/vendor/event-listener-5.4.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "event-listener-5.4.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/event-listener-5.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.5.4.crate",
         "sha256": "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93",
-        "dest": "cargo/vendor/event-listener-strategy-0.5.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "event-listener-strategy-0.5.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/event-listener-strategy-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/fastrand/fastrand-2.3.0.crate",
         "sha256": "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be",
-        "dest": "cargo/vendor/fastrand-2.3.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "fastrand-2.3.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2237909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/fastrand-2.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/field-offset/field-offset-0.3.6.crate",
         "sha256": "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f",
-        "dest": "cargo/vendor/field-offset-0.3.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "field-offset-0.3.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2238e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/field-offset-0.3.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/filetime/filetime-0.2.25.crate",
         "sha256": "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586",
-        "dest": "cargo/vendor/filetime-0.2.25"
+        "dest": "cargo/vendor",
+        "dest-filename": "filetime-0.2.25.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2235c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/filetime-0.2.25",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/flate2/flate2-1.1.2.crate",
         "sha256": "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d",
-        "dest": "cargo/vendor/flate2-1.1.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "flate2-1.1.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/flate2-1.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/fluent-bundle/fluent-bundle-0.15.3.crate",
         "sha256": "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493",
-        "dest": "cargo/vendor/fluent-bundle-0.15.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "fluent-bundle-0.15.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/fluent-bundle-0.15.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/fluent-langneg/fluent-langneg-0.13.0.crate",
         "sha256": "2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94",
-        "dest": "cargo/vendor/fluent-langneg-0.13.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "fluent-langneg-0.13.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/fluent-langneg-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/fluent-syntax/fluent-syntax-0.11.1.crate",
         "sha256": "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d",
-        "dest": "cargo/vendor/fluent-syntax-0.11.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "fluent-syntax-0.11.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/fluent-syntax-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/fluent-template-macros/fluent-template-macros-0.13.0.crate",
         "sha256": "4ed02449601d0dacdc05cb5e13db5dab8f2b98d773aff5c53b62fad43a1b19a1",
-        "dest": "cargo/vendor/fluent-template-macros-0.13.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "fluent-template-macros-0.13.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"4ed02449601d0dacdc05cb5e13db5dab8f2b98d773aff5c53b62fad43a1b19a1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224ed02449601d0dacdc05cb5e13db5dab8f2b98d773aff5c53b62fad43a1b19a1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/fluent-template-macros-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/fluent-templates/fluent-templates-0.13.0.crate",
         "sha256": "69855a5fe87629495efca79aec72adfa97954f1006f928e3a2ec750cb3e85386",
-        "dest": "cargo/vendor/fluent-templates-0.13.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "fluent-templates-0.13.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"69855a5fe87629495efca79aec72adfa97954f1006f928e3a2ec750cb3e85386\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2269855a5fe87629495efca79aec72adfa97954f1006f928e3a2ec750cb3e85386%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/fluent-templates-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/flume/flume-0.11.1.crate",
         "sha256": "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095",
-        "dest": "cargo/vendor/flume-0.11.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "flume-0.11.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/flume-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/fnv/fnv-1.0.7.crate",
         "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
-        "dest": "cargo/vendor/fnv-1.0.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "fnv-1.0.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/fnv-1.0.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.2.1.crate",
         "sha256": "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456",
-        "dest": "cargo/vendor/form_urlencoded-1.2.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "form_urlencoded-1.2.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/form_urlencoded-1.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/fragile/fragile-2.0.1.crate",
         "sha256": "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619",
-        "dest": "cargo/vendor/fragile-2.0.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "fragile-2.0.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2228dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/fragile-2.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/fs_extra/fs_extra-1.3.0.crate",
         "sha256": "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c",
-        "dest": "cargo/vendor/fs_extra-1.3.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "fs_extra-1.3.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2242703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/fs_extra-1.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures/futures-0.3.31.crate",
         "sha256": "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876",
-        "dest": "cargo/vendor/futures-0.3.31"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-0.3.31.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2265bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.31.crate",
         "sha256": "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10",
-        "dest": "cargo/vendor/futures-channel-0.3.31"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-channel-0.3.31.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-channel-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.31.crate",
         "sha256": "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e",
-        "dest": "cargo/vendor/futures-core-0.3.31"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-core-0.3.31.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2205f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-core-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.31.crate",
         "sha256": "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f",
-        "dest": "cargo/vendor/futures-executor-0.3.31"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-executor-0.3.31.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-executor-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.31.crate",
         "sha256": "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6",
-        "dest": "cargo/vendor/futures-io-0.3.31"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-io-0.3.31.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-io-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures-lite/futures-lite-2.6.0.crate",
         "sha256": "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532",
-        "dest": "cargo/vendor/futures-lite-2.6.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-lite-2.6.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-lite-2.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.31.crate",
         "sha256": "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650",
-        "dest": "cargo/vendor/futures-macro-0.3.31"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-macro-0.3.31.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-macro-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.31.crate",
         "sha256": "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7",
-        "dest": "cargo/vendor/futures-sink-0.3.31"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-sink-0.3.31.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-sink-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.31.crate",
         "sha256": "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988",
-        "dest": "cargo/vendor/futures-task-0.3.31"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-task-0.3.31.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-task-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.31.crate",
         "sha256": "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81",
-        "dest": "cargo/vendor/futures-util-0.3.31"
+        "dest": "cargo/vendor",
+        "dest-filename": "futures-util-0.3.31.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/futures-util-0.3.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.20.10.crate",
         "sha256": "2fd242894c084f4beed508a56952750bce3e96e85eb68fdc153637daa163e10c",
-        "dest": "cargo/vendor/gdk-pixbuf-0.20.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "gdk-pixbuf-0.20.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2fd242894c084f4beed508a56952750bce3e96e85eb68fdc153637daa163e10c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222fd242894c084f4beed508a56952750bce3e96e85eb68fdc153637daa163e10c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gdk-pixbuf-0.20.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.20.10.crate",
         "sha256": "5b34f3b580c988bd217e9543a2de59823fafae369d1a055555e5f95a8b130b96",
-        "dest": "cargo/vendor/gdk-pixbuf-sys-0.20.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "gdk-pixbuf-sys-0.20.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5b34f3b580c988bd217e9543a2de59823fafae369d1a055555e5f95a8b130b96\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225b34f3b580c988bd217e9543a2de59823fafae369d1a055555e5f95a8b130b96%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gdk-pixbuf-sys-0.20.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gdk4/gdk4-0.9.6.crate",
         "sha256": "4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60",
-        "dest": "cargo/vendor/gdk4-0.9.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "gdk4-0.9.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gdk4-0.9.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.9.6.crate",
         "sha256": "6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a",
-        "dest": "cargo/vendor/gdk4-sys-0.9.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "gdk4-sys-0.9.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gdk4-sys-0.9.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/generic-array/generic-array-0.14.7.crate",
         "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
-        "dest": "cargo/vendor/generic-array-0.14.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "generic-array-0.14.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2285649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/generic-array-0.14.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.16.crate",
         "sha256": "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592",
-        "dest": "cargo/vendor/getrandom-0.2.16"
+        "dest": "cargo/vendor",
+        "dest-filename": "getrandom-0.2.16.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/getrandom-0.2.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/getrandom/getrandom-0.3.3.crate",
         "sha256": "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4",
-        "dest": "cargo/vendor/getrandom-0.3.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "getrandom-0.3.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2226145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/getrandom-0.3.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gimli/gimli-0.31.1.crate",
         "sha256": "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f",
-        "dest": "cargo/vendor/gimli-0.31.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "gimli-0.31.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2207e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gimli-0.31.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gio/gio-0.20.12.crate",
         "sha256": "8e27e276e7b6b8d50f6376ee7769a71133e80d093bdc363bd0af71664228b831",
-        "dest": "cargo/vendor/gio-0.20.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "gio-0.20.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8e27e276e7b6b8d50f6376ee7769a71133e80d093bdc363bd0af71664228b831\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228e27e276e7b6b8d50f6376ee7769a71133e80d093bdc363bd0af71664228b831%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gio-0.20.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.20.10.crate",
         "sha256": "521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83",
-        "dest": "cargo/vendor/gio-sys-0.20.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "gio-sys-0.20.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gio-sys-0.20.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/glib/glib-0.20.12.crate",
         "sha256": "ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683",
-        "dest": "cargo/vendor/glib-0.20.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "glib-0.20.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/glib-0.20.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/glib-build-tools/glib-build-tools-0.20.0.crate",
         "sha256": "7029c2651d9b5d5a3eea93ec8a1995665c6d3a69ce9bf6042ad9064d134736d8",
-        "dest": "cargo/vendor/glib-build-tools-0.20.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "glib-build-tools-0.20.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7029c2651d9b5d5a3eea93ec8a1995665c6d3a69ce9bf6042ad9064d134736d8\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227029c2651d9b5d5a3eea93ec8a1995665c6d3a69ce9bf6042ad9064d134736d8%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/glib-build-tools-0.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.20.12.crate",
         "sha256": "e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145",
-        "dest": "cargo/vendor/glib-macros-0.20.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "glib-macros-0.20.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/glib-macros-0.20.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.20.10.crate",
         "sha256": "8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215",
-        "dest": "cargo/vendor/glib-sys-0.20.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "glib-sys-0.20.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/glib-sys-0.20.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/globset/globset-0.4.16.crate",
         "sha256": "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5",
-        "dest": "cargo/vendor/globset-0.4.16"
+        "dest": "cargo/vendor",
+        "dest-filename": "globset-0.4.16.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2254a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/globset-0.4.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.20.10.crate",
         "sha256": "ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda",
-        "dest": "cargo/vendor/gobject-sys-0.20.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "gobject-sys-0.20.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gobject-sys-0.20.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.20.10.crate",
         "sha256": "6b86dfad7d14251c9acaf1de63bc8754b7e3b4e5b16777b6f5a748208fe9519b",
-        "dest": "cargo/vendor/graphene-rs-0.20.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "graphene-rs-0.20.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6b86dfad7d14251c9acaf1de63bc8754b7e3b4e5b16777b6f5a748208fe9519b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226b86dfad7d14251c9acaf1de63bc8754b7e3b4e5b16777b6f5a748208fe9519b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/graphene-rs-0.20.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.20.10.crate",
         "sha256": "df583a85ba2d5e15e1797e40d666057b28bc2f60a67c9c24145e6db2cc3861ea",
-        "dest": "cargo/vendor/graphene-sys-0.20.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "graphene-sys-0.20.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"df583a85ba2d5e15e1797e40d666057b28bc2f60a67c9c24145e6db2cc3861ea\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22df583a85ba2d5e15e1797e40d666057b28bc2f60a67c9c24145e6db2cc3861ea%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/graphene-sys-0.20.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gsk4/gsk4-0.9.6.crate",
         "sha256": "61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855",
-        "dest": "cargo/vendor/gsk4-0.9.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "gsk4-0.9.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2261f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gsk4-0.9.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.9.6.crate",
         "sha256": "755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc",
-        "dest": "cargo/vendor/gsk4-sys-0.9.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "gsk4-sys-0.9.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gsk4-sys-0.9.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gtk4/gtk4-0.9.7.crate",
         "sha256": "f274dd0102c21c47bbfa8ebcb92d0464fab794a22fad6c3f3d5f165139a326d6",
-        "dest": "cargo/vendor/gtk4-0.9.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "gtk4-0.9.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f274dd0102c21c47bbfa8ebcb92d0464fab794a22fad6c3f3d5f165139a326d6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f274dd0102c21c47bbfa8ebcb92d0464fab794a22fad6c3f3d5f165139a326d6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gtk4-0.9.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.9.5.crate",
         "sha256": "0ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999",
-        "dest": "cargo/vendor/gtk4-macros-0.9.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "gtk4-macros-0.9.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gtk4-macros-0.9.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.9.6.crate",
         "sha256": "41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6",
-        "dest": "cargo/vendor/gtk4-sys-0.9.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "gtk4-sys-0.9.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2241e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/gtk4-sys-0.9.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/h2/h2-0.4.10.crate",
-        "sha256": "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5",
-        "dest": "cargo/vendor/h2-0.4.10"
+        "type": "file",
+        "url": "https://static.crates.io/crates/h2/h2-0.4.11.crate",
+        "sha256": "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785",
+        "dest": "cargo/vendor",
+        "dest-filename": "h2-0.4.11.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5\", \"files\": {}}",
-        "dest": "cargo/vendor/h2-0.4.10",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2217da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/h2-0.4.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.5.crate",
         "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
-        "dest": "cargo/vendor/hashbrown-0.14.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "hashbrown-0.14.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/hashbrown-0.14.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.15.4.crate",
         "sha256": "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5",
-        "dest": "cargo/vendor/hashbrown-0.15.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "hashbrown-0.15.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/hashbrown-0.15.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/heck/heck-0.5.0.crate",
         "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
-        "dest": "cargo/vendor/heck-0.5.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "heck-0.5.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/heck-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/hex/hex-0.4.3.crate",
         "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
-        "dest": "cargo/vendor/hex-0.4.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "hex-0.4.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/hex-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/hmac/hmac-0.12.1.crate",
         "sha256": "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e",
-        "dest": "cargo/vendor/hmac-0.12.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "hmac-0.12.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/hmac-0.12.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/home/home-0.5.11.crate",
         "sha256": "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf",
-        "dest": "cargo/vendor/home-0.5.11"
+        "dest": "cargo/vendor",
+        "dest-filename": "home-0.5.11.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/home-0.5.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/http/http-1.3.1.crate",
         "sha256": "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565",
-        "dest": "cargo/vendor/http-1.3.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "http-1.3.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/http-1.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/http-body/http-body-1.0.1.crate",
         "sha256": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184",
-        "dest": "cargo/vendor/http-body-1.0.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "http-body-1.0.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/http-body-1.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/http-body-util/http-body-util-0.1.3.crate",
         "sha256": "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a",
-        "dest": "cargo/vendor/http-body-util-0.1.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "http-body-util-0.1.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/http-body-util-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/httparse/httparse-1.10.1.crate",
         "sha256": "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87",
-        "dest": "cargo/vendor/httparse-1.10.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "httparse-1.10.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/httparse-1.10.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/human-panic/human-panic-2.0.2.crate",
-        "sha256": "80b84a66a325082740043a6c28bbea400c129eac0d3a27673a1de971e44bf1f7",
-        "dest": "cargo/vendor/human-panic-2.0.2"
+        "type": "file",
+        "url": "https://static.crates.io/crates/human-panic/human-panic-2.0.3.crate",
+        "sha256": "ac63a746b187e95d51fe16850eb04d1cfef203f6af98e6c405a6f262ad3df00a",
+        "dest": "cargo/vendor",
+        "dest-filename": "human-panic-2.0.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"80b84a66a325082740043a6c28bbea400c129eac0d3a27673a1de971e44bf1f7\", \"files\": {}}",
-        "dest": "cargo/vendor/human-panic-2.0.2",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ac63a746b187e95d51fe16850eb04d1cfef203f6af98e6c405a6f262ad3df00a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/human-panic-2.0.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/hyper/hyper-1.6.0.crate",
         "sha256": "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80",
-        "dest": "cargo/vendor/hyper-1.6.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "hyper-1.6.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/hyper-1.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/hyper-rustls/hyper-rustls-0.27.7.crate",
         "sha256": "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58",
-        "dest": "cargo/vendor/hyper-rustls-0.27.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "hyper-rustls-0.27.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/hyper-rustls-0.27.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/hyper-util/hyper-util-0.1.14.crate",
-        "sha256": "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb",
-        "dest": "cargo/vendor/hyper-util-0.1.14"
+        "type": "file",
+        "url": "https://static.crates.io/crates/hyper-util/hyper-util-0.1.15.crate",
+        "sha256": "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df",
+        "dest": "cargo/vendor",
+        "dest-filename": "hyper-util-0.1.15.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb\", \"files\": {}}",
-        "dest": "cargo/vendor/hyper-util-0.1.14",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/hyper-util-0.1.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/icu_collections/icu_collections-2.0.0.crate",
         "sha256": "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47",
-        "dest": "cargo/vendor/icu_collections-2.0.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "icu_collections-2.0.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/icu_collections-2.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/icu_locale_core/icu_locale_core-2.0.0.crate",
         "sha256": "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a",
-        "dest": "cargo/vendor/icu_locale_core-2.0.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "icu_locale_core-2.0.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/icu_locale_core-2.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/icu_normalizer/icu_normalizer-2.0.0.crate",
         "sha256": "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979",
-        "dest": "cargo/vendor/icu_normalizer-2.0.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "icu_normalizer-2.0.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/icu_normalizer-2.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/icu_normalizer_data/icu_normalizer_data-2.0.0.crate",
         "sha256": "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3",
-        "dest": "cargo/vendor/icu_normalizer_data-2.0.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "icu_normalizer_data-2.0.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2200210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/icu_normalizer_data-2.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/icu_properties/icu_properties-2.0.1.crate",
         "sha256": "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b",
-        "dest": "cargo/vendor/icu_properties-2.0.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "icu_properties-2.0.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/icu_properties-2.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/icu_properties_data/icu_properties_data-2.0.1.crate",
         "sha256": "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632",
-        "dest": "cargo/vendor/icu_properties_data-2.0.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "icu_properties_data-2.0.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/icu_properties_data-2.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/icu_provider/icu_provider-2.0.0.crate",
         "sha256": "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af",
-        "dest": "cargo/vendor/icu_provider-2.0.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "icu_provider-2.0.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2203c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/icu_provider-2.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/ident_case/ident_case-1.0.1.crate",
         "sha256": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39",
-        "dest": "cargo/vendor/ident_case-1.0.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "ident_case-1.0.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ident_case-1.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/idna/idna-1.0.3.crate",
         "sha256": "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e",
-        "dest": "cargo/vendor/idna-1.0.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "idna-1.0.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/idna-1.0.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/idna_adapter/idna_adapter-1.2.1.crate",
         "sha256": "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344",
-        "dest": "cargo/vendor/idna_adapter-1.2.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "idna_adapter-1.2.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/idna_adapter-1.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/ignore/ignore-0.4.23.crate",
         "sha256": "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b",
-        "dest": "cargo/vendor/ignore-0.4.23"
+        "dest": "cargo/vendor",
+        "dest-filename": "ignore-0.4.23.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ignore-0.4.23",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/indexmap/indexmap-2.9.0.crate",
-        "sha256": "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e",
-        "dest": "cargo/vendor/indexmap-2.9.0"
+        "type": "file",
+        "url": "https://static.crates.io/crates/indexmap/indexmap-2.10.0.crate",
+        "sha256": "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661",
+        "dest": "cargo/vendor",
+        "dest-filename": "indexmap-2.10.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e\", \"files\": {}}",
-        "dest": "cargo/vendor/indexmap-2.9.0",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/indexmap-2.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/inout/inout-0.1.4.crate",
         "sha256": "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01",
-        "dest": "cargo/vendor/inout-0.1.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "inout-0.1.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/inout-0.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/intl-memoizer/intl-memoizer-0.5.3.crate",
         "sha256": "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f",
-        "dest": "cargo/vendor/intl-memoizer-0.5.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "intl-memoizer-0.5.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/intl-memoizer-0.5.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/intl_pluralrules/intl_pluralrules-7.0.2.crate",
         "sha256": "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972",
-        "dest": "cargo/vendor/intl_pluralrules-7.0.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "intl_pluralrules-7.0.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/intl_pluralrules-7.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/ipnet/ipnet-2.11.0.crate",
-        "sha256": "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130",
-        "dest": "cargo/vendor/ipnet-2.11.0"
+        "type": "file",
+        "url": "https://static.crates.io/crates/io-uring/io-uring-0.7.8.crate",
+        "sha256": "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013",
+        "dest": "cargo/vendor",
+        "dest-filename": "io-uring-0.7.8.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/io-uring-0.7.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/ipnet/ipnet-2.11.0.crate",
+        "sha256": "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130",
+        "dest": "cargo/vendor",
+        "dest-filename": "ipnet-2.11.0.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ipnet-2.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/iri-string/iri-string-0.7.8.crate",
         "sha256": "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2",
-        "dest": "cargo/vendor/iri-string-0.7.8"
+        "dest": "cargo/vendor",
+        "dest-filename": "iri-string-0.7.8.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/iri-string-0.7.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/is-docker/is-docker-0.2.0.crate",
         "sha256": "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3",
-        "dest": "cargo/vendor/is-docker-0.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "is-docker-0.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/is-docker-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/is-wsl/is-wsl-0.4.0.crate",
         "sha256": "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5",
-        "dest": "cargo/vendor/is-wsl-0.4.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "is-wsl-0.4.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/is-wsl-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/is_terminal_polyfill/is_terminal_polyfill-1.70.1.crate",
         "sha256": "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf",
-        "dest": "cargo/vendor/is_terminal_polyfill-1.70.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "is_terminal_polyfill-1.70.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/is_terminal_polyfill-1.70.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/itoa/itoa-1.0.15.crate",
         "sha256": "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c",
-        "dest": "cargo/vendor/itoa-1.0.15"
+        "dest": "cargo/vendor",
+        "dest-filename": "itoa-1.0.15.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/itoa-1.0.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/jobserver/jobserver-0.1.33.crate",
         "sha256": "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a",
-        "dest": "cargo/vendor/jobserver-0.1.33"
+        "dest": "cargo/vendor",
+        "dest-filename": "jobserver-0.1.33.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2238f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/jobserver-0.1.33",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.77.crate",
         "sha256": "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f",
-        "dest": "cargo/vendor/js-sys-0.3.77"
+        "dest": "cargo/vendor",
+        "dest-filename": "js-sys-0.3.77.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/js-sys-0.3.77",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/kinda-virtual-fs/kinda-virtual-fs-0.1.1.crate",
         "sha256": "ca9325aac17917b5650f25d477ce2909f2e9539688227fdee3ceb5093f666c9e",
-        "dest": "cargo/vendor/kinda-virtual-fs-0.1.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "kinda-virtual-fs-0.1.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ca9325aac17917b5650f25d477ce2909f2e9539688227fdee3ceb5093f666c9e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ca9325aac17917b5650f25d477ce2909f2e9539688227fdee3ceb5093f666c9e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/kinda-virtual-fs-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.5.0.crate",
         "sha256": "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe",
-        "dest": "cargo/vendor/lazy_static-1.5.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "lazy_static-1.5.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/lazy_static-1.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/libadwaita/libadwaita-0.7.2.crate",
         "sha256": "500135d29c16aabf67baafd3e7741d48e8b8978ca98bac39e589165c8dc78191",
-        "dest": "cargo/vendor/libadwaita-0.7.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "libadwaita-0.7.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"500135d29c16aabf67baafd3e7741d48e8b8978ca98bac39e589165c8dc78191\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22500135d29c16aabf67baafd3e7741d48e8b8978ca98bac39e589165c8dc78191%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/libadwaita-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/libadwaita-sys/libadwaita-sys-0.7.2.crate",
         "sha256": "6680988058c2558baf3f548a370e4e78da3bf7f08469daa822ac414842c912db",
-        "dest": "cargo/vendor/libadwaita-sys-0.7.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "libadwaita-sys-0.7.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6680988058c2558baf3f548a370e4e78da3bf7f08469daa822ac414842c912db\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226680988058c2558baf3f548a370e4e78da3bf7f08469daa822ac414842c912db%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/libadwaita-sys-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/libc/libc-0.2.174.crate",
         "sha256": "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776",
-        "dest": "cargo/vendor/libc-0.2.174"
+        "dest": "cargo/vendor",
+        "dest-filename": "libc-0.2.174.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/libc-0.2.174",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/libredox/libredox-0.1.3.crate",
-        "sha256": "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d",
-        "dest": "cargo/vendor/libredox-0.1.3"
+        "type": "file",
+        "url": "https://static.crates.io/crates/libredox/libredox-0.1.4.crate",
+        "sha256": "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638",
+        "dest": "cargo/vendor",
+        "dest-filename": "libredox-0.1.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d\", \"files\": {}}",
-        "dest": "cargo/vendor/libredox-0.1.3",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/libredox-0.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/libz-rs-sys/libz-rs-sys-0.5.1.crate",
         "sha256": "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221",
-        "dest": "cargo/vendor/libz-rs-sys-0.5.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "libz-rs-sys-0.5.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/libz-rs-sys-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.4.15.crate",
         "sha256": "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab",
-        "dest": "cargo/vendor/linux-raw-sys-0.4.15"
+        "dest": "cargo/vendor",
+        "dest-filename": "linux-raw-sys-0.4.15.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/linux-raw-sys-0.4.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.9.4.crate",
         "sha256": "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12",
-        "dest": "cargo/vendor/linux-raw-sys-0.9.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "linux-raw-sys-0.9.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/linux-raw-sys-0.9.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/litemap/litemap-0.8.0.crate",
         "sha256": "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956",
-        "dest": "cargo/vendor/litemap-0.8.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "litemap-0.8.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/litemap-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.13.crate",
         "sha256": "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765",
-        "dest": "cargo/vendor/lock_api-0.4.13"
+        "dest": "cargo/vendor",
+        "dest-filename": "lock_api-0.4.13.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2296936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/lock_api-0.4.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/log/log-0.4.27.crate",
         "sha256": "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94",
-        "dest": "cargo/vendor/log-0.4.27"
+        "dest": "cargo/vendor",
+        "dest-filename": "log-0.4.27.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2213dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/log-0.4.27",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/lru-slab/lru-slab-0.1.2.crate",
         "sha256": "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154",
-        "dest": "cargo/vendor/lru-slab-0.1.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "lru-slab-0.1.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/lru-slab-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/lzma-rs/lzma-rs-0.3.0.crate",
         "sha256": "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e",
-        "dest": "cargo/vendor/lzma-rs-0.3.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "lzma-rs-0.3.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/lzma-rs-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/lzma-sys/lzma-sys-0.1.20.crate",
         "sha256": "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27",
-        "dest": "cargo/vendor/lzma-sys-0.1.20"
+        "dest": "cargo/vendor",
+        "dest-filename": "lzma-sys-0.1.20.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/lzma-sys-0.1.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/md-5/md-5-0.10.6.crate",
         "sha256": "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf",
-        "dest": "cargo/vendor/md-5-0.10.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "md-5-0.10.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/md-5-0.10.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/md5-asm/md5-asm-0.5.2.crate",
         "sha256": "d19b8ee7fc7d812058d3b708c7f719efd0713d53854648e4223c6fcae709e2df",
-        "dest": "cargo/vendor/md5-asm-0.5.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "md5-asm-0.5.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d19b8ee7fc7d812058d3b708c7f719efd0713d53854648e4223c6fcae709e2df\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d19b8ee7fc7d812058d3b708c7f719efd0713d53854648e4223c6fcae709e2df%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/md5-asm-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/memchr/memchr-2.7.5.crate",
         "sha256": "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0",
-        "dest": "cargo/vendor/memchr-2.7.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "memchr-2.7.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2232a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/memchr-2.7.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/memoffset/memoffset-0.9.1.crate",
         "sha256": "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a",
-        "dest": "cargo/vendor/memoffset-0.9.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "memoffset-0.9.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/memoffset-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.8.9.crate",
         "sha256": "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316",
-        "dest": "cargo/vendor/miniz_oxide-0.8.9"
+        "dest": "cargo/vendor",
+        "dest-filename": "miniz_oxide-0.8.9.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/miniz_oxide-0.8.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/minreq/minreq-2.13.4.crate",
-        "sha256": "f0d2aaba477837b46ec1289588180fabfccf0c3b1d1a0c6b1866240cd6cd5ce9",
-        "dest": "cargo/vendor/minreq-2.13.4"
+        "type": "file",
+        "url": "https://static.crates.io/crates/minreq/minreq-2.14.0.crate",
+        "sha256": "84885312a86831bff4a3cb04a1e54a3f698407e3274c83249313f194d3e0b678",
+        "dest": "cargo/vendor",
+        "dest-filename": "minreq-2.14.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f0d2aaba477837b46ec1289588180fabfccf0c3b1d1a0c6b1866240cd6cd5ce9\", \"files\": {}}",
-        "dest": "cargo/vendor/minreq-2.13.4",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2284885312a86831bff4a3cb04a1e54a3f698407e3274c83249313f194d3e0b678%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/minreq-2.14.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/mio/mio-1.0.4.crate",
         "sha256": "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c",
-        "dest": "cargo/vendor/mio-1.0.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "mio-1.0.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2278bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/mio-1.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/nanorand/nanorand-0.7.0.crate",
         "sha256": "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3",
-        "dest": "cargo/vendor/nanorand-0.7.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "nanorand-0.7.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/nanorand-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/nix/nix-0.30.1.crate",
         "sha256": "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6",
-        "dest": "cargo/vendor/nix-0.30.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "nix-0.30.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2274523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/nix-0.30.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/ntapi/ntapi-0.4.1.crate",
         "sha256": "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4",
-        "dest": "cargo/vendor/ntapi-0.4.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "ntapi-0.4.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ntapi-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/nu-ansi-term/nu-ansi-term-0.46.0.crate",
         "sha256": "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84",
-        "dest": "cargo/vendor/nu-ansi-term-0.46.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "nu-ansi-term-0.46.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2277a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/nu-ansi-term-0.46.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/num-conv/num-conv-0.1.0.crate",
         "sha256": "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9",
-        "dest": "cargo/vendor/num-conv-0.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "num-conv-0.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2251d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/num-conv-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/objc2/objc2-0.6.1.crate",
         "sha256": "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551",
-        "dest": "cargo/vendor/objc2-0.6.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "objc2-0.6.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2288c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/objc2-0.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/objc2-app-kit/objc2-app-kit-0.3.1.crate",
         "sha256": "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc",
-        "dest": "cargo/vendor/objc2-app-kit-0.3.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "objc2-app-kit-0.3.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/objc2-app-kit-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/objc2-core-foundation/objc2-core-foundation-0.3.1.crate",
         "sha256": "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166",
-        "dest": "cargo/vendor/objc2-core-foundation-0.3.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "objc2-core-foundation-0.3.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/objc2-core-foundation-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/objc2-encode/objc2-encode-4.1.0.crate",
         "sha256": "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33",
-        "dest": "cargo/vendor/objc2-encode-4.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "objc2-encode-4.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/objc2-encode-4.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/objc2-foundation/objc2-foundation-0.3.1.crate",
         "sha256": "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c",
-        "dest": "cargo/vendor/objc2-foundation-0.3.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "objc2-foundation-0.3.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/objc2-foundation-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/objc2-io-kit/objc2-io-kit-0.3.1.crate",
         "sha256": "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a",
-        "dest": "cargo/vendor/objc2-io-kit-0.3.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "objc2-io-kit-0.3.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2271c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/objc2-io-kit-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/object/object-0.36.7.crate",
         "sha256": "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87",
-        "dest": "cargo/vendor/object-0.36.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "object-0.36.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2262948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/object-0.36.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/once_cell/once_cell-1.21.3.crate",
         "sha256": "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d",
-        "dest": "cargo/vendor/once_cell-1.21.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "once_cell-1.21.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2242f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/once_cell-1.21.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/once_cell_polyfill/once_cell_polyfill-1.70.1.crate",
         "sha256": "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad",
-        "dest": "cargo/vendor/once_cell_polyfill-1.70.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "once_cell_polyfill-1.70.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/once_cell_polyfill-1.70.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/open/open-5.3.2.crate",
         "sha256": "e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95",
-        "dest": "cargo/vendor/open-5.3.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "open-5.3.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e2483562e62ea94312f3576a7aca397306df7990b8d89033e18766744377ef95%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/open-5.3.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/openssl-probe/openssl-probe-0.1.6.crate",
         "sha256": "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e",
-        "dest": "cargo/vendor/openssl-probe-0.1.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "openssl-probe-0.1.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/openssl-probe-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/ordered-stream/ordered-stream-0.2.0.crate",
         "sha256": "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50",
-        "dest": "cargo/vendor/ordered-stream-0.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "ordered-stream-0.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ordered-stream-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/os_info/os_info-3.12.0.crate",
         "sha256": "d0e1ac5fde8d43c34139135df8ea9ee9465394b2d8d20f032d38998f64afffc3",
-        "dest": "cargo/vendor/os_info-3.12.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "os_info-3.12.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d0e1ac5fde8d43c34139135df8ea9ee9465394b2d8d20f032d38998f64afffc3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d0e1ac5fde8d43c34139135df8ea9ee9465394b2d8d20f032d38998f64afffc3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/os_info-3.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/overload/overload-0.1.1.crate",
         "sha256": "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39",
-        "dest": "cargo/vendor/overload-0.1.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "overload-0.1.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/overload-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/pango/pango-0.20.12.crate",
         "sha256": "6576b311f6df659397043a5fa8a021da8f72e34af180b44f7d57348de691ab5c",
-        "dest": "cargo/vendor/pango-0.20.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "pango-0.20.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6576b311f6df659397043a5fa8a021da8f72e34af180b44f7d57348de691ab5c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226576b311f6df659397043a5fa8a021da8f72e34af180b44f7d57348de691ab5c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/pango-0.20.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.20.10.crate",
         "sha256": "186909673fc09be354555c302c0b3dcf753cd9fa08dcb8077fa663c80fb243fa",
-        "dest": "cargo/vendor/pango-sys-0.20.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "pango-sys-0.20.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"186909673fc09be354555c302c0b3dcf753cd9fa08dcb8077fa663c80fb243fa\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22186909673fc09be354555c302c0b3dcf753cd9fa08dcb8077fa663c80fb243fa%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/pango-sys-0.20.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/parking/parking-2.2.1.crate",
         "sha256": "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba",
-        "dest": "cargo/vendor/parking-2.2.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "parking-2.2.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/parking-2.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/pathdiff/pathdiff-0.2.3.crate",
         "sha256": "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3",
-        "dest": "cargo/vendor/pathdiff-0.2.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "pathdiff-0.2.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/pathdiff-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/pbkdf2/pbkdf2-0.12.2.crate",
         "sha256": "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2",
-        "dest": "cargo/vendor/pbkdf2-0.12.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "pbkdf2-0.12.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/pbkdf2-0.12.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.3.1.crate",
         "sha256": "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e",
-        "dest": "cargo/vendor/percent-encoding-2.3.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "percent-encoding-2.3.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/percent-encoding-2.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.16.crate",
         "sha256": "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b",
-        "dest": "cargo/vendor/pin-project-lite-0.2.16"
+        "dest": "cargo/vendor",
+        "dest-filename": "pin-project-lite-0.2.16.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/pin-project-lite-0.2.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/pin-utils/pin-utils-0.1.0.crate",
         "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
-        "dest": "cargo/vendor/pin-utils-0.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "pin-utils-0.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/pin-utils-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.32.crate",
         "sha256": "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c",
-        "dest": "cargo/vendor/pkg-config-0.3.32"
+        "dest": "cargo/vendor",
+        "dest-filename": "pkg-config-0.3.32.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/pkg-config-0.3.32",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/plist/plist-1.7.2.crate",
-        "sha256": "3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed",
-        "dest": "cargo/vendor/plist-1.7.2"
+        "type": "file",
+        "url": "https://static.crates.io/crates/plist/plist-1.7.4.crate",
+        "sha256": "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1",
+        "dest": "cargo/vendor",
+        "dest-filename": "plist-1.7.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed\", \"files\": {}}",
-        "dest": "cargo/vendor/plist-1.7.2",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/plist-1.7.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/pollster/pollster-0.4.0.crate",
         "sha256": "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3",
-        "dest": "cargo/vendor/pollster-0.4.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "pollster-0.4.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/pollster-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/potential_utf/potential_utf-0.1.2.crate",
         "sha256": "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585",
-        "dest": "cargo/vendor/potential_utf-0.1.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "potential_utf-0.1.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/potential_utf-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/powerfmt/powerfmt-0.2.0.crate",
         "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
-        "dest": "cargo/vendor/powerfmt-0.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "powerfmt-0.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/powerfmt-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.21.crate",
         "sha256": "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9",
-        "dest": "cargo/vendor/ppv-lite86-0.2.21"
+        "dest": "cargo/vendor",
+        "dest-filename": "ppv-lite86-0.2.21.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2285eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ppv-lite86-0.2.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.3.0.crate",
         "sha256": "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35",
-        "dest": "cargo/vendor/proc-macro-crate-3.3.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "proc-macro-crate-3.3.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/proc-macro-crate-3.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/proc-macro-hack/proc-macro-hack-0.5.20+deprecated.crate",
         "sha256": "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068",
-        "dest": "cargo/vendor/proc-macro-hack-0.5.20+deprecated"
+        "dest": "cargo/vendor",
+        "dest-filename": "proc-macro-hack-0.5.20+deprecated.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/proc-macro-hack-0.5.20+deprecated",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.95.crate",
         "sha256": "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778",
-        "dest": "cargo/vendor/proc-macro2-1.0.95"
+        "dest": "cargo/vendor",
+        "dest-filename": "proc-macro2-1.0.95.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2202b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/proc-macro2-1.0.95",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/protobuf/protobuf-3.7.2.crate",
         "sha256": "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4",
-        "dest": "cargo/vendor/protobuf-3.7.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "protobuf-3.7.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/protobuf-3.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/protobuf-codegen/protobuf-codegen-3.7.2.crate",
         "sha256": "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace",
-        "dest": "cargo/vendor/protobuf-codegen-3.7.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "protobuf-codegen-3.7.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/protobuf-codegen-3.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/protobuf-parse/protobuf-parse-3.7.2.crate",
         "sha256": "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973",
-        "dest": "cargo/vendor/protobuf-parse-3.7.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "protobuf-parse-3.7.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/protobuf-parse-3.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/protobuf-support/protobuf-support-3.7.2.crate",
         "sha256": "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6",
-        "dest": "cargo/vendor/protobuf-support-3.7.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "protobuf-support-3.7.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/protobuf-support-3.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.37.5.crate",
-        "sha256": "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb",
-        "dest": "cargo/vendor/quick-xml-0.37.5"
+        "type": "file",
+        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.38.0.crate",
+        "sha256": "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b",
+        "dest": "cargo/vendor",
+        "dest-filename": "quick-xml-0.38.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb\", \"files\": {}}",
-        "dest": "cargo/vendor/quick-xml-0.37.5",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/quick-xml-0.38.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/quinn/quinn-0.11.8.crate",
         "sha256": "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8",
-        "dest": "cargo/vendor/quinn-0.11.8"
+        "dest": "cargo/vendor",
+        "dest-filename": "quinn-0.11.8.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/quinn-0.11.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/quinn-proto/quinn-proto-0.11.12.crate",
         "sha256": "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e",
-        "dest": "cargo/vendor/quinn-proto-0.11.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "quinn-proto-0.11.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2249df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/quinn-proto-0.11.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/quinn-udp/quinn-udp-0.5.13.crate",
         "sha256": "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970",
-        "dest": "cargo/vendor/quinn-udp-0.5.13"
+        "dest": "cargo/vendor",
+        "dest-filename": "quinn-udp-0.5.13.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/quinn-udp-0.5.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/quote/quote-1.0.40.crate",
         "sha256": "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d",
-        "dest": "cargo/vendor/quote-1.0.40"
+        "dest": "cargo/vendor",
+        "dest-filename": "quote-1.0.40.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/quote-1.0.40",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/r-efi/r-efi-5.3.0.crate",
         "sha256": "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f",
-        "dest": "cargo/vendor/r-efi-5.3.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "r-efi-5.3.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2269cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/r-efi-5.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rand/rand-0.9.1.crate",
         "sha256": "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97",
-        "dest": "cargo/vendor/rand-0.9.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "rand-0.9.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rand-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.9.0.crate",
         "sha256": "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb",
-        "dest": "cargo/vendor/rand_chacha-0.9.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "rand_chacha-0.9.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rand_chacha-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rand_core/rand_core-0.9.3.crate",
         "sha256": "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38",
-        "dest": "cargo/vendor/rand_core-0.9.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "rand_core-0.9.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2299d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rand_core-0.9.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.6.2.crate",
         "sha256": "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539",
-        "dest": "cargo/vendor/raw-window-handle-0.6.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "raw-window-handle-0.6.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2220675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/raw-window-handle-0.6.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.5.13.crate",
         "sha256": "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6",
-        "dest": "cargo/vendor/redox_syscall-0.5.13"
+        "dest": "cargo/vendor",
+        "dest-filename": "redox_syscall-0.5.13.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/redox_syscall-0.5.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/regex/regex-1.11.1.crate",
         "sha256": "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191",
-        "dest": "cargo/vendor/regex-1.11.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "regex-1.11.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/regex-1.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.9.crate",
         "sha256": "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908",
-        "dest": "cargo/vendor/regex-automata-0.4.9"
+        "dest": "cargo/vendor",
+        "dest-filename": "regex-automata-0.4.9.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/regex-automata-0.4.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.5.crate",
         "sha256": "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c",
-        "dest": "cargo/vendor/regex-syntax-0.8.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "regex-syntax-0.8.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/regex-syntax-0.8.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/relm4/relm4-0.9.1.crate",
         "sha256": "30837553c1a8cfea1a404c83ec387c5c8ff9358e1060b057c274c5daa5035ad1",
-        "dest": "cargo/vendor/relm4-0.9.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "relm4-0.9.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"30837553c1a8cfea1a404c83ec387c5c8ff9358e1060b057c274c5daa5035ad1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2230837553c1a8cfea1a404c83ec387c5c8ff9358e1060b057c274c5daa5035ad1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/relm4-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/relm4-css/relm4-css-0.9.0.crate",
         "sha256": "1d3b924557df1cddc687b60b313c4b76620fdbf0e463afa4b29f67193ccf37f9",
-        "dest": "cargo/vendor/relm4-css-0.9.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "relm4-css-0.9.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1d3b924557df1cddc687b60b313c4b76620fdbf0e463afa4b29f67193ccf37f9\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221d3b924557df1cddc687b60b313c4b76620fdbf0e463afa4b29f67193ccf37f9%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/relm4-css-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/relm4-macros/relm4-macros-0.9.1.crate",
         "sha256": "5a895a7455441a857d100ca679bd24a92f91d28b5e3df63296792ac1af2eddde",
-        "dest": "cargo/vendor/relm4-macros-0.9.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "relm4-macros-0.9.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5a895a7455441a857d100ca679bd24a92f91d28b5e3df63296792ac1af2eddde\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225a895a7455441a857d100ca679bd24a92f91d28b5e3df63296792ac1af2eddde%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/relm4-macros-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/reqwest/reqwest-0.12.20.crate",
-        "sha256": "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813",
-        "dest": "cargo/vendor/reqwest-0.12.20"
+        "type": "file",
+        "url": "https://static.crates.io/crates/reqwest/reqwest-0.12.22.crate",
+        "sha256": "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531",
+        "dest": "cargo/vendor",
+        "dest-filename": "reqwest-0.12.22.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813\", \"files\": {}}",
-        "dest": "cargo/vendor/reqwest-0.12.20",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/reqwest-0.12.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rfd/rfd-0.15.3.crate",
         "sha256": "80c844748fdc82aae252ee4594a89b6e7ebef1063de7951545564cbc4e57075d",
-        "dest": "cargo/vendor/rfd-0.15.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "rfd-0.15.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"80c844748fdc82aae252ee4594a89b6e7ebef1063de7951545564cbc4e57075d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2280c844748fdc82aae252ee4594a89b6e7ebef1063de7951545564cbc4e57075d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rfd-0.15.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/ring/ring-0.17.14.crate",
         "sha256": "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7",
-        "dest": "cargo/vendor/ring-0.17.14"
+        "dest": "cargo/vendor",
+        "dest-filename": "ring-0.17.14.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ring-0.17.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustc-demangle/rustc-demangle-0.1.25.crate",
         "sha256": "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f",
-        "dest": "cargo/vendor/rustc-demangle-0.1.25"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustc-demangle-0.1.25.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustc-demangle-0.1.25",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustc-hash/rustc-hash-1.1.0.crate",
         "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
-        "dest": "cargo/vendor/rustc-hash-1.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustc-hash-1.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2208d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustc-hash-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustc-hash/rustc-hash-2.1.1.crate",
         "sha256": "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d",
-        "dest": "cargo/vendor/rustc-hash-2.1.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustc-hash-2.1.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustc-hash-2.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.1.crate",
         "sha256": "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92",
-        "dest": "cargo/vendor/rustc_version-0.4.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustc_version-0.4.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustc_version-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustix/rustix-0.38.44.crate",
         "sha256": "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154",
-        "dest": "cargo/vendor/rustix-0.38.44"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustix-0.38.44.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustix-0.38.44",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustix/rustix-1.0.7.crate",
         "sha256": "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266",
-        "dest": "cargo/vendor/rustix-1.0.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustix-1.0.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustix-1.0.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustls/rustls-0.21.12.crate",
         "sha256": "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e",
-        "dest": "cargo/vendor/rustls-0.21.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustls-0.21.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustls-0.21.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustls/rustls-0.23.28.crate",
-        "sha256": "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643",
-        "dest": "cargo/vendor/rustls-0.23.28"
+        "type": "file",
+        "url": "https://static.crates.io/crates/rustls/rustls-0.23.29.crate",
+        "sha256": "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1",
+        "dest": "cargo/vendor",
+        "dest-filename": "rustls-0.23.29.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643\", \"files\": {}}",
-        "dest": "cargo/vendor/rustls-0.23.28",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/rustls-0.23.29",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustls-native-certs/rustls-native-certs-0.6.3.crate",
         "sha256": "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00",
-        "dest": "cargo/vendor/rustls-native-certs-0.6.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustls-native-certs-0.6.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustls-native-certs-0.6.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustls-pemfile/rustls-pemfile-1.0.4.crate",
         "sha256": "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c",
-        "dest": "cargo/vendor/rustls-pemfile-1.0.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustls-pemfile-1.0.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustls-pemfile-1.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustls-pki-types/rustls-pki-types-1.12.0.crate",
         "sha256": "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79",
-        "dest": "cargo/vendor/rustls-pki-types-1.12.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustls-pki-types-1.12.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustls-pki-types-1.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustls-webpki/rustls-webpki-0.101.7.crate",
         "sha256": "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765",
-        "dest": "cargo/vendor/rustls-webpki-0.101.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustls-webpki-0.101.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustls-webpki-0.101.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/rustls-webpki/rustls-webpki-0.103.3.crate",
-        "sha256": "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435",
-        "dest": "cargo/vendor/rustls-webpki-0.103.3"
+        "type": "file",
+        "url": "https://static.crates.io/crates/rustls-webpki/rustls-webpki-0.103.4.crate",
+        "sha256": "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc",
+        "dest": "cargo/vendor",
+        "dest-filename": "rustls-webpki-0.103.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435\", \"files\": {}}",
-        "dest": "cargo/vendor/rustls-webpki-0.103.3",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/rustls-webpki-0.103.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/rustversion/rustversion-1.0.21.crate",
         "sha256": "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d",
-        "dest": "cargo/vendor/rustversion-1.0.21"
+        "dest": "cargo/vendor",
+        "dest-filename": "rustversion-1.0.21.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/rustversion-1.0.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/ryu/ryu-1.0.20.crate",
         "sha256": "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f",
-        "dest": "cargo/vendor/ryu-1.0.20"
+        "dest": "cargo/vendor",
+        "dest-filename": "ryu-1.0.20.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2228d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/ryu-1.0.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/same-file/same-file-1.0.6.crate",
         "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
-        "dest": "cargo/vendor/same-file-1.0.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "same-file-1.0.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2293fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/same-file-1.0.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/schannel/schannel-0.1.27.crate",
         "sha256": "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d",
-        "dest": "cargo/vendor/schannel-0.1.27"
+        "dest": "cargo/vendor",
+        "dest-filename": "schannel-0.1.27.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/schannel-0.1.27",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.2.0.crate",
         "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
-        "dest": "cargo/vendor/scopeguard-1.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "scopeguard-1.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2294143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/scopeguard-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/sct/sct-0.7.1.crate",
         "sha256": "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414",
-        "dest": "cargo/vendor/sct-0.7.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "sct-0.7.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/sct-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/security-framework/security-framework-2.11.1.crate",
         "sha256": "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02",
-        "dest": "cargo/vendor/security-framework-2.11.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "security-framework-2.11.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/security-framework-2.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/security-framework-sys/security-framework-sys-2.14.0.crate",
         "sha256": "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32",
-        "dest": "cargo/vendor/security-framework-sys-2.14.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "security-framework-sys-2.14.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2249db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/security-framework-sys-2.14.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/self_cell/self_cell-0.10.3.crate",
         "sha256": "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d",
-        "dest": "cargo/vendor/self_cell-0.10.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "self_cell-0.10.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/self_cell-0.10.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/self_cell/self_cell-1.2.0.crate",
         "sha256": "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749",
-        "dest": "cargo/vendor/self_cell-1.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "self_cell-1.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/self_cell-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/semver/semver-1.0.26.crate",
         "sha256": "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0",
-        "dest": "cargo/vendor/semver-1.0.26"
+        "dest": "cargo/vendor",
+        "dest-filename": "semver-1.0.26.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2256e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/semver-1.0.26",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/serde/serde-1.0.219.crate",
         "sha256": "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6",
-        "dest": "cargo/vendor/serde-1.0.219"
+        "dest": "cargo/vendor",
+        "dest-filename": "serde-1.0.219.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/serde-1.0.219",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.219.crate",
         "sha256": "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00",
-        "dest": "cargo/vendor/serde_derive-1.0.219"
+        "dest": "cargo/vendor",
+        "dest-filename": "serde_derive-1.0.219.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/serde_derive-1.0.219",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.140.crate",
         "sha256": "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373",
-        "dest": "cargo/vendor/serde_json-1.0.140"
+        "dest": "cargo/vendor",
+        "dest-filename": "serde_json-1.0.140.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2220068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/serde_json-1.0.140",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/serde_repr/serde_repr-0.1.20.crate",
         "sha256": "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c",
-        "dest": "cargo/vendor/serde_repr-0.1.20"
+        "dest": "cargo/vendor",
+        "dest-filename": "serde_repr-0.1.20.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/serde_repr-0.1.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.9.crate",
         "sha256": "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3",
-        "dest": "cargo/vendor/serde_spanned-0.6.9"
+        "dest": "cargo/vendor",
+        "dest-filename": "serde_spanned-0.6.9.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/serde_spanned-0.6.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_urlencoded/serde_urlencoded-0.7.1.crate",
-        "sha256": "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd",
-        "dest": "cargo/vendor/serde_urlencoded-0.7.1"
+        "type": "file",
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-1.0.0.crate",
+        "sha256": "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83",
+        "dest": "cargo/vendor",
+        "dest-filename": "serde_spanned-1.0.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2240734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/serde_spanned-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/serde_urlencoded/serde_urlencoded-0.7.1.crate",
+        "sha256": "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd",
+        "dest": "cargo/vendor",
+        "dest-filename": "serde_urlencoded-0.7.1.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/serde_urlencoded-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/sha1/sha1-0.10.6.crate",
         "sha256": "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba",
-        "dest": "cargo/vendor/sha1-0.10.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "sha1-0.10.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/sha1-0.10.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/sharded-slab/sharded-slab-0.1.7.crate",
         "sha256": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
-        "dest": "cargo/vendor/sharded-slab-0.1.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "sharded-slab-0.1.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/sharded-slab-0.1.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/shlex/shlex-1.3.0.crate",
         "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
-        "dest": "cargo/vendor/shlex-1.3.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "shlex-1.3.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/shlex-1.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.5.crate",
         "sha256": "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410",
-        "dest": "cargo/vendor/signal-hook-registry-1.4.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "signal-hook-registry-1.4.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/signal-hook-registry-1.4.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/simd-adler32/simd-adler32-0.3.7.crate",
         "sha256": "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe",
-        "dest": "cargo/vendor/simd-adler32-0.3.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "simd-adler32-0.3.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/simd-adler32-0.3.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/slab/slab-0.4.10.crate",
         "sha256": "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d",
-        "dest": "cargo/vendor/slab-0.4.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "slab-0.4.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2204dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/slab-0.4.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/smallvec/smallvec-1.15.1.crate",
         "sha256": "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03",
-        "dest": "cargo/vendor/smallvec-1.15.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "smallvec-1.15.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2267b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/smallvec-1.15.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/socket2/socket2-0.5.10.crate",
         "sha256": "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678",
-        "dest": "cargo/vendor/socket2-0.5.10"
+        "dest": "cargo/vendor",
+        "dest-filename": "socket2-0.5.10.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/socket2-0.5.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/spin/spin-0.9.8.crate",
         "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
-        "dest": "cargo/vendor/spin-0.9.8"
+        "dest": "cargo/vendor",
+        "dest-filename": "spin-0.9.8.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/spin-0.9.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/stable_deref_trait/stable_deref_trait-1.2.0.crate",
         "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3",
-        "dest": "cargo/vendor/stable_deref_trait-1.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "stable_deref_trait-1.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/stable_deref_trait-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/static_assertions/static_assertions-1.1.0.crate",
         "sha256": "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f",
-        "dest": "cargo/vendor/static_assertions-1.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "static_assertions-1.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/static_assertions-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/strsim/strsim-0.11.1.crate",
         "sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f",
-        "dest": "cargo/vendor/strsim-0.11.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "strsim-0.11.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/strsim-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/subtle/subtle-2.6.1.crate",
         "sha256": "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292",
-        "dest": "cargo/vendor/subtle-2.6.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "subtle-2.6.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2213c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/subtle-2.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/syn/syn-2.0.104.crate",
         "sha256": "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40",
-        "dest": "cargo/vendor/syn-2.0.104"
+        "dest": "cargo/vendor",
+        "dest-filename": "syn-2.0.104.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2217b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/syn-2.0.104",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/sync_wrapper/sync_wrapper-1.0.2.crate",
         "sha256": "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263",
-        "dest": "cargo/vendor/sync_wrapper-1.0.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "sync_wrapper-1.0.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/sync_wrapper-1.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/synstructure/synstructure-0.13.2.crate",
         "sha256": "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2",
-        "dest": "cargo/vendor/synstructure-0.13.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "synstructure-0.13.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/synstructure-0.13.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/sysinfo/sysinfo-0.35.2.crate",
         "sha256": "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e",
-        "dest": "cargo/vendor/sysinfo-0.35.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "sysinfo-0.35.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/sysinfo-0.35.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/system-deps/system-deps-7.0.5.crate",
         "sha256": "e4be53aa0cba896d2dc615bd42bbc130acdcffa239e0a2d965ea5b3b2a86ffdb",
-        "dest": "cargo/vendor/system-deps-7.0.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "system-deps-7.0.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e4be53aa0cba896d2dc615bd42bbc130acdcffa239e0a2d965ea5b3b2a86ffdb\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e4be53aa0cba896d2dc615bd42bbc130acdcffa239e0a2d965ea5b3b2a86ffdb%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/system-deps-7.0.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tar/tar-0.4.44.crate",
         "sha256": "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a",
-        "dest": "cargo/vendor/tar-0.4.44"
+        "dest": "cargo/vendor",
+        "dest-filename": "tar-0.4.44.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tar-0.4.44",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.13.2.crate",
         "sha256": "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a",
-        "dest": "cargo/vendor/target-lexicon-0.13.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "target-lexicon-0.13.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/target-lexicon-0.13.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tempfile/tempfile-3.20.0.crate",
         "sha256": "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1",
-        "dest": "cargo/vendor/tempfile-3.20.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "tempfile-3.20.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tempfile-3.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.69.crate",
         "sha256": "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52",
-        "dest": "cargo/vendor/thiserror-1.0.69"
+        "dest": "cargo/vendor",
+        "dest-filename": "thiserror-1.0.69.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/thiserror-1.0.69",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/thiserror/thiserror-2.0.12.crate",
         "sha256": "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708",
-        "dest": "cargo/vendor/thiserror-2.0.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "thiserror-2.0.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/thiserror-2.0.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.69.crate",
         "sha256": "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1",
-        "dest": "cargo/vendor/thiserror-impl-1.0.69"
+        "dest": "cargo/vendor",
+        "dest-filename": "thiserror-impl-1.0.69.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/thiserror-impl-1.0.69",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-2.0.12.crate",
         "sha256": "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d",
-        "dest": "cargo/vendor/thiserror-impl-2.0.12"
+        "dest": "cargo/vendor",
+        "dest-filename": "thiserror-impl-2.0.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/thiserror-impl-2.0.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/thread_local/thread_local-1.1.9.crate",
         "sha256": "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185",
-        "dest": "cargo/vendor/thread_local-1.1.9"
+        "dest": "cargo/vendor",
+        "dest-filename": "thread_local-1.1.9.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/thread_local-1.1.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/time/time-0.3.41.crate",
         "sha256": "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40",
-        "dest": "cargo/vendor/time-0.3.41"
+        "dest": "cargo/vendor",
+        "dest-filename": "time-0.3.41.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/time-0.3.41",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/time-core/time-core-0.1.4.crate",
         "sha256": "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c",
-        "dest": "cargo/vendor/time-core-0.1.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "time-core-0.1.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/time-core-0.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.22.crate",
         "sha256": "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49",
-        "dest": "cargo/vendor/time-macros-0.2.22"
+        "dest": "cargo/vendor",
+        "dest-filename": "time-macros-0.2.22.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/time-macros-0.2.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tinystr/tinystr-0.8.1.crate",
         "sha256": "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b",
-        "dest": "cargo/vendor/tinystr-0.8.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "tinystr-0.8.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tinystr-0.8.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tinyvec/tinyvec-1.9.0.crate",
         "sha256": "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71",
-        "dest": "cargo/vendor/tinyvec-1.9.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "tinyvec-1.9.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2209b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tinyvec-1.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tinyvec_macros/tinyvec_macros-0.1.1.crate",
         "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
-        "dest": "cargo/vendor/tinyvec_macros-0.1.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "tinyvec_macros-0.1.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tinyvec_macros-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/tokio/tokio-1.45.1.crate",
-        "sha256": "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779",
-        "dest": "cargo/vendor/tokio-1.45.1"
+        "type": "file",
+        "url": "https://static.crates.io/crates/tokio/tokio-1.46.1.crate",
+        "sha256": "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17",
+        "dest": "cargo/vendor",
+        "dest-filename": "tokio-1.46.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779\", \"files\": {}}",
-        "dest": "cargo/vendor/tokio-1.45.1",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/tokio-1.46.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tokio-rustls/tokio-rustls-0.26.2.crate",
         "sha256": "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b",
-        "dest": "cargo/vendor/tokio-rustls-0.26.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "tokio-rustls-0.26.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tokio-rustls-0.26.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tokio-util/tokio-util-0.7.15.crate",
         "sha256": "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df",
-        "dest": "cargo/vendor/tokio-util-0.7.15"
+        "dest": "cargo/vendor",
+        "dest-filename": "tokio-util-0.7.15.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2266a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tokio-util-0.7.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/toml/toml-0.8.23.crate",
         "sha256": "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362",
-        "dest": "cargo/vendor/toml-0.8.23"
+        "dest": "cargo/vendor",
+        "dest-filename": "toml-0.8.23.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/toml-0.8.23",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.11.crate",
-        "sha256": "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c",
-        "dest": "cargo/vendor/toml_datetime-0.6.11"
+        "type": "file",
+        "url": "https://static.crates.io/crates/toml/toml-0.9.2.crate",
+        "sha256": "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac",
+        "dest": "cargo/vendor",
+        "dest-filename": "toml-0.9.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/toml-0.9.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.11.crate",
+        "sha256": "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c",
+        "dest": "cargo/vendor",
+        "dest-filename": "toml_datetime-0.6.11.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2222cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/toml_datetime-0.6.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.22.27.crate",
-        "sha256": "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a",
-        "dest": "cargo/vendor/toml_edit-0.22.27"
+        "type": "file",
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.7.0.crate",
+        "sha256": "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3",
+        "dest": "cargo/vendor",
+        "dest-filename": "toml_datetime-0.7.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/toml_datetime-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "file",
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.22.27.crate",
+        "sha256": "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a",
+        "dest": "cargo/vendor",
+        "dest-filename": "toml_edit-0.22.27.crate"
+    },
+    {
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2241fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/toml_edit-0.22.27",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/toml_write/toml_write-0.1.2.crate",
-        "sha256": "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801",
-        "dest": "cargo/vendor/toml_write-0.1.2"
+        "type": "file",
+        "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.0.0.crate",
+        "sha256": "b679217f2848de74cabd3e8fc5e6d66f40b7da40f8e1954d92054d9010690fd5",
+        "dest": "cargo/vendor",
+        "dest-filename": "toml_writer-1.0.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801\", \"files\": {}}",
-        "dest": "cargo/vendor/toml_write-0.1.2",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b679217f2848de74cabd3e8fc5e6d66f40b7da40f8e1954d92054d9010690fd5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/toml_writer-1.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tower/tower-0.5.2.crate",
         "sha256": "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9",
-        "dest": "cargo/vendor/tower-0.5.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "tower-0.5.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tower-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tower-http/tower-http-0.6.6.crate",
         "sha256": "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2",
-        "dest": "cargo/vendor/tower-http-0.6.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "tower-http-0.6.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tower-http-0.6.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tower-layer/tower-layer-0.3.3.crate",
         "sha256": "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e",
-        "dest": "cargo/vendor/tower-layer-0.3.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "tower-layer-0.3.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tower-layer-0.3.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tower-service/tower-service-0.3.3.crate",
         "sha256": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3",
-        "dest": "cargo/vendor/tower-service-0.3.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "tower-service-0.3.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tower-service-0.3.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tracing/tracing-0.1.41.crate",
         "sha256": "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0",
-        "dest": "cargo/vendor/tracing-0.1.41"
+        "dest": "cargo/vendor",
+        "dest-filename": "tracing-0.1.41.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tracing-0.1.41",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tracing-attributes/tracing-attributes-0.1.30.crate",
         "sha256": "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903",
-        "dest": "cargo/vendor/tracing-attributes-0.1.30"
+        "dest": "cargo/vendor",
+        "dest-filename": "tracing-attributes-0.1.30.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2281383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tracing-attributes-0.1.30",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.34.crate",
         "sha256": "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678",
-        "dest": "cargo/vendor/tracing-core-0.1.34"
+        "dest": "cargo/vendor",
+        "dest-filename": "tracing-core-0.1.34.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tracing-core-0.1.34",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tracing-log/tracing-log-0.2.0.crate",
         "sha256": "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
-        "dest": "cargo/vendor/tracing-log-0.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "tracing-log-0.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tracing-log-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/tracing-subscriber/tracing-subscriber-0.3.19.crate",
         "sha256": "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008",
-        "dest": "cargo/vendor/tracing-subscriber-0.3.19"
+        "dest": "cargo/vendor",
+        "dest-filename": "tracing-subscriber-0.3.19.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/tracing-subscriber-0.3.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/try-lock/try-lock-0.2.5.crate",
         "sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b",
-        "dest": "cargo/vendor/try-lock-0.2.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "try-lock-0.2.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/try-lock-0.2.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/type-map/type-map-0.5.1.crate",
         "sha256": "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90",
-        "dest": "cargo/vendor/type-map-0.5.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "type-map-0.5.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/type-map-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/typenum/typenum-1.18.0.crate",
         "sha256": "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f",
-        "dest": "cargo/vendor/typenum-1.18.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "typenum-1.18.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/typenum-1.18.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/uds_windows/uds_windows-1.1.0.crate",
         "sha256": "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9",
-        "dest": "cargo/vendor/uds_windows-1.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "uds_windows-1.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2289daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/uds_windows-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/unic-langid/unic-langid-0.9.6.crate",
         "sha256": "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05",
-        "dest": "cargo/vendor/unic-langid-0.9.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "unic-langid-0.9.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/unic-langid-0.9.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/unic-langid-impl/unic-langid-impl-0.9.6.crate",
         "sha256": "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658",
-        "dest": "cargo/vendor/unic-langid-impl-0.9.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "unic-langid-impl-0.9.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/unic-langid-impl-0.9.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/unic-langid-macros/unic-langid-macros-0.9.6.crate",
         "sha256": "d5957eb82e346d7add14182a3315a7e298f04e1ba4baac36f7f0dbfedba5fc25",
-        "dest": "cargo/vendor/unic-langid-macros-0.9.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "unic-langid-macros-0.9.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d5957eb82e346d7add14182a3315a7e298f04e1ba4baac36f7f0dbfedba5fc25\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d5957eb82e346d7add14182a3315a7e298f04e1ba4baac36f7f0dbfedba5fc25%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/unic-langid-macros-0.9.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/unic-langid-macros-impl/unic-langid-macros-impl-0.9.6.crate",
         "sha256": "a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5",
-        "dest": "cargo/vendor/unic-langid-macros-impl-0.9.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "unic-langid-macros-impl-0.9.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a1249a628de3ad34b821ecb1001355bca3940bcb2f88558f1a8bd82e977f75b5%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/unic-langid-macros-impl-0.9.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.18.crate",
         "sha256": "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512",
-        "dest": "cargo/vendor/unicode-ident-1.0.18"
+        "dest": "cargo/vendor",
+        "dest-filename": "unicode-ident-1.0.18.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/unicode-ident-1.0.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/untrusted/untrusted-0.9.0.crate",
         "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
-        "dest": "cargo/vendor/untrusted-0.9.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "untrusted-0.9.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/untrusted-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/url/url-2.5.4.crate",
         "sha256": "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60",
-        "dest": "cargo/vendor/url-2.5.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "url-2.5.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2232f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/url-2.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/urlencoding/urlencoding-2.1.3.crate",
         "sha256": "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da",
-        "dest": "cargo/vendor/urlencoding-2.1.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "urlencoding-2.1.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/urlencoding-2.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/utf8_iter/utf8_iter-1.0.4.crate",
         "sha256": "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be",
-        "dest": "cargo/vendor/utf8_iter-1.0.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "utf8_iter-1.0.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/utf8_iter-1.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/utf8parse/utf8parse-0.2.2.crate",
         "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
-        "dest": "cargo/vendor/utf8parse-0.2.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "utf8parse-0.2.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2206abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/utf8parse-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/uuid/uuid-1.17.0.crate",
         "sha256": "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d",
-        "dest": "cargo/vendor/uuid-1.17.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "uuid-1.17.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/uuid-1.17.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/valuable/valuable-0.1.1.crate",
         "sha256": "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65",
-        "dest": "cargo/vendor/valuable-0.1.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "valuable-0.1.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/valuable-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/version-compare/version-compare-0.2.0.crate",
         "sha256": "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b",
-        "dest": "cargo/vendor/version-compare-0.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "version-compare-0.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/version-compare-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/version_check/version_check-0.9.5.crate",
         "sha256": "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a",
-        "dest": "cargo/vendor/version_check-0.9.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "version_check-0.9.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/version_check-0.9.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/walkdir/walkdir-2.5.0.crate",
         "sha256": "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b",
-        "dest": "cargo/vendor/walkdir-2.5.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "walkdir-2.5.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2229790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/walkdir-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/want/want-0.3.1.crate",
         "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
-        "dest": "cargo/vendor/want-0.3.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "want-0.3.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/want-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wasi/wasi-0.11.1+wasi-snapshot-preview1.crate",
         "sha256": "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b",
-        "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1"
+        "dest": "cargo/vendor",
+        "dest-filename": "wasi-0.11.1+wasi-snapshot-preview1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wasi/wasi-0.14.2+wasi-0.2.4.crate",
         "sha256": "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3",
-        "dest": "cargo/vendor/wasi-0.14.2+wasi-0.2.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "wasi-0.14.2+wasi-0.2.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wasi-0.14.2+wasi-0.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.100.crate",
         "sha256": "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5",
-        "dest": "cargo/vendor/wasm-bindgen-0.2.100"
+        "dest": "cargo/vendor",
+        "dest-filename": "wasm-bindgen-0.2.100.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wasm-bindgen-0.2.100",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.100.crate",
         "sha256": "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6",
-        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.100"
+        "dest": "cargo/vendor",
+        "dest-filename": "wasm-bindgen-backend-0.2.100.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wasm-bindgen-backend-0.2.100",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.50.crate",
         "sha256": "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61",
-        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.50"
+        "dest": "cargo/vendor",
+        "dest-filename": "wasm-bindgen-futures-0.4.50.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wasm-bindgen-futures-0.4.50",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.100.crate",
         "sha256": "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407",
-        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.100"
+        "dest": "cargo/vendor",
+        "dest-filename": "wasm-bindgen-macro-0.2.100.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wasm-bindgen-macro-0.2.100",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.100.crate",
         "sha256": "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de",
-        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.100"
+        "dest": "cargo/vendor",
+        "dest-filename": "wasm-bindgen-macro-support-0.2.100.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.100",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.100.crate",
         "sha256": "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d",
-        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.100"
+        "dest": "cargo/vendor",
+        "dest-filename": "wasm-bindgen-shared-0.2.100.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wasm-bindgen-shared-0.2.100",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.77.crate",
         "sha256": "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2",
-        "dest": "cargo/vendor/web-sys-0.3.77"
+        "dest": "cargo/vendor",
+        "dest-filename": "web-sys-0.3.77.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2233b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/web-sys-0.3.77",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/web-time/web-time-1.1.0.crate",
         "sha256": "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb",
-        "dest": "cargo/vendor/web-time-1.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "web-time-1.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/web-time-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/webpki-roots/webpki-roots-0.25.4.crate",
         "sha256": "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1",
-        "dest": "cargo/vendor/webpki-roots-0.25.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "webpki-roots-0.25.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/webpki-roots-0.25.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/webpki-roots/webpki-roots-1.0.1.crate",
         "sha256": "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502",
-        "dest": "cargo/vendor/webpki-roots-1.0.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "webpki-roots-1.0.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/webpki-roots-1.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/whatadistro/whatadistro-0.1.0.crate",
         "sha256": "1c97ebad4f59809511083f2161587445631bff21bb78d9e046b9ca5b2d05d913",
-        "dest": "cargo/vendor/whatadistro-0.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "whatadistro-0.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1c97ebad4f59809511083f2161587445631bff21bb78d9e046b9ca5b2d05d913\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221c97ebad4f59809511083f2161587445631bff21bb78d9e046b9ca5b2d05d913%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/whatadistro-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/which/which-4.4.2.crate",
         "sha256": "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7",
-        "dest": "cargo/vendor/which-4.4.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "which-4.4.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2287ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/which-4.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
         "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
-        "dest": "cargo/vendor/winapi-0.3.9"
+        "dest": "cargo/vendor",
+        "dest-filename": "winapi-0.3.9.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/winapi-0.3.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
         "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
-        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "winapi-i686-pc-windows-gnu-0.4.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.9.crate",
         "sha256": "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb",
-        "dest": "cargo/vendor/winapi-util-0.1.9"
+        "dest": "cargo/vendor",
+        "dest-filename": "winapi-util-0.1.9.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/winapi-util-0.1.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
         "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "winapi-x86_64-pc-windows-gnu-0.4.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wincompatlib/wincompatlib-0.7.7.crate",
         "sha256": "aae41600d3750bfc93d709117e7099510d5e2ea40a228b8288384dd8e7f5cd04",
-        "dest": "cargo/vendor/wincompatlib-0.7.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "wincompatlib-0.7.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"aae41600d3750bfc93d709117e7099510d5e2ea40a228b8288384dd8e7f5cd04\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22aae41600d3750bfc93d709117e7099510d5e2ea40a228b8288384dd8e7f5cd04%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wincompatlib-0.7.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows/windows-0.61.3.crate",
         "sha256": "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893",
-        "dest": "cargo/vendor/windows-0.61.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-0.61.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-0.61.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-collections/windows-collections-0.2.0.crate",
         "sha256": "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8",
-        "dest": "cargo/vendor/windows-collections-0.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-collections-0.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-collections-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-core/windows-core-0.61.2.crate",
         "sha256": "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3",
-        "dest": "cargo/vendor/windows-core-0.61.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-core-0.61.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-core-0.61.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-future/windows-future-0.2.1.crate",
         "sha256": "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e",
-        "dest": "cargo/vendor/windows-future-0.2.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-future-0.2.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-future-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-implement/windows-implement-0.60.0.crate",
         "sha256": "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836",
-        "dest": "cargo/vendor/windows-implement-0.60.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-implement-0.60.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-implement-0.60.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-interface/windows-interface-0.59.1.crate",
         "sha256": "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8",
-        "dest": "cargo/vendor/windows-interface-0.59.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-interface-0.59.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-interface-0.59.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-link/windows-link-0.1.3.crate",
         "sha256": "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a",
-        "dest": "cargo/vendor/windows-link-0.1.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-link-0.1.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-link-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-numerics/windows-numerics-0.2.0.crate",
         "sha256": "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1",
-        "dest": "cargo/vendor/windows-numerics-0.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-numerics-0.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-numerics-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-result/windows-result-0.3.4.crate",
         "sha256": "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6",
-        "dest": "cargo/vendor/windows-result-0.3.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-result-0.3.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2256f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-result-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-strings/windows-strings-0.4.2.crate",
         "sha256": "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57",
-        "dest": "cargo/vendor/windows-strings-0.4.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-strings-0.4.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2256e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-strings-0.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.48.0.crate",
         "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
-        "dest": "cargo/vendor/windows-sys-0.48.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-sys-0.48.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-sys-0.48.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.52.0.crate",
         "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
-        "dest": "cargo/vendor/windows-sys-0.52.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-sys-0.52.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-sys-0.52.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.59.0.crate",
         "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
-        "dest": "cargo/vendor/windows-sys-0.59.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-sys-0.59.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-sys-0.59.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.60.2.crate",
         "sha256": "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb",
-        "dest": "cargo/vendor/windows-sys-0.60.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-sys-0.60.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-sys-0.60.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.48.5.crate",
         "sha256": "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c",
-        "dest": "cargo/vendor/windows-targets-0.48.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-targets-0.48.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-targets-0.48.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.6.crate",
         "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
-        "dest": "cargo/vendor/windows-targets-0.52.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-targets-0.52.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-targets-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.53.2.crate",
         "sha256": "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef",
-        "dest": "cargo/vendor/windows-targets-0.53.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-targets-0.53.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-targets-0.53.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows-threading/windows-threading-0.1.0.crate",
         "sha256": "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6",
-        "dest": "cargo/vendor/windows-threading-0.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows-threading-0.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows-threading-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.48.5.crate",
         "sha256": "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8",
-        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_aarch64_gnullvm-0.48.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.6.crate",
         "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
-        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_aarch64_gnullvm-0.52.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2232a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.53.0.crate",
         "sha256": "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764",
-        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.53.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_aarch64_gnullvm-0.53.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2286b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_aarch64_gnullvm-0.53.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.48.5.crate",
         "sha256": "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc",
-        "dest": "cargo/vendor/windows_aarch64_msvc-0.48.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_aarch64_msvc-0.48.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_aarch64_msvc-0.48.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.6.crate",
         "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
-        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_aarch64_msvc-0.52.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2209ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.53.0.crate",
         "sha256": "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c",
-        "dest": "cargo/vendor/windows_aarch64_msvc-0.53.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_aarch64_msvc-0.53.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_aarch64_msvc-0.53.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.48.5.crate",
         "sha256": "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e",
-        "dest": "cargo/vendor/windows_i686_gnu-0.48.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_i686_gnu-0.48.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_i686_gnu-0.48.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.6.crate",
         "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
-        "dest": "cargo/vendor/windows_i686_gnu-0.52.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_i686_gnu-0.52.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_i686_gnu-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.53.0.crate",
         "sha256": "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3",
-        "dest": "cargo/vendor/windows_i686_gnu-0.53.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_i686_gnu-0.53.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_i686_gnu-0.53.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.52.6.crate",
         "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
-        "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_i686_gnullvm-0.52.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.53.0.crate",
         "sha256": "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11",
-        "dest": "cargo/vendor/windows_i686_gnullvm-0.53.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_i686_gnullvm-0.53.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_i686_gnullvm-0.53.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.48.5.crate",
         "sha256": "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406",
-        "dest": "cargo/vendor/windows_i686_msvc-0.48.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_i686_msvc-0.48.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_i686_msvc-0.48.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.6.crate",
         "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
-        "dest": "cargo/vendor/windows_i686_msvc-0.52.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_i686_msvc-0.52.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_i686_msvc-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.53.0.crate",
         "sha256": "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d",
-        "dest": "cargo/vendor/windows_i686_msvc-0.53.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_i686_msvc-0.53.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_i686_msvc-0.53.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.48.5.crate",
         "sha256": "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e",
-        "dest": "cargo/vendor/windows_x86_64_gnu-0.48.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_x86_64_gnu-0.48.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2253d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_x86_64_gnu-0.48.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.6.crate",
         "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
-        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_x86_64_gnu-0.52.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.53.0.crate",
         "sha256": "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba",
-        "dest": "cargo/vendor/windows_x86_64_gnu-0.53.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_x86_64_gnu-0.53.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%222e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_x86_64_gnu-0.53.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.48.5.crate",
         "sha256": "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc",
-        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_x86_64_gnullvm-0.48.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.6.crate",
         "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
-        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_x86_64_gnullvm-0.52.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2224d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.53.0.crate",
         "sha256": "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57",
-        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.53.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_x86_64_gnullvm-0.53.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%220a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_x86_64_gnullvm-0.53.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.48.5.crate",
         "sha256": "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538",
-        "dest": "cargo/vendor/windows_x86_64_msvc-0.48.5"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_x86_64_msvc-0.48.5.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_x86_64_msvc-0.48.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.6.crate",
         "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
-        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_x86_64_msvc-0.52.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.53.0.crate",
         "sha256": "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486",
-        "dest": "cargo/vendor/windows_x86_64_msvc-0.53.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "windows_x86_64_msvc-0.53.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/windows_x86_64_msvc-0.53.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winnow/winnow-0.7.11.crate",
-        "sha256": "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd",
-        "dest": "cargo/vendor/winnow-0.7.11"
+        "type": "file",
+        "url": "https://static.crates.io/crates/winnow/winnow-0.7.12.crate",
+        "sha256": "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95",
+        "dest": "cargo/vendor",
+        "dest-filename": "winnow-0.7.12.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd\", \"files\": {}}",
-        "dest": "cargo/vendor/winnow-0.7.11",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/winnow-0.7.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/wit-bindgen-rt/wit-bindgen-rt-0.39.0.crate",
         "sha256": "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1",
-        "dest": "cargo/vendor/wit-bindgen-rt-0.39.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "wit-bindgen-rt-0.39.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%226f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/wit-bindgen-rt-0.39.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/writeable/writeable-0.6.1.crate",
         "sha256": "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb",
-        "dest": "cargo/vendor/writeable-0.6.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "writeable-0.6.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/writeable-0.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/xattr/xattr-1.5.0.crate",
-        "sha256": "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e",
-        "dest": "cargo/vendor/xattr-1.5.0"
+        "type": "file",
+        "url": "https://static.crates.io/crates/xattr/xattr-1.5.1.crate",
+        "sha256": "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909",
+        "dest": "cargo/vendor",
+        "dest-filename": "xattr-1.5.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e\", \"files\": {}}",
-        "dest": "cargo/vendor/xattr-1.5.0",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/xattr-1.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/xz/xz-0.1.0.crate",
         "sha256": "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34",
-        "dest": "cargo/vendor/xz-0.1.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "xz-0.1.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/xz-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/xz2/xz2-0.1.7.crate",
         "sha256": "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2",
-        "dest": "cargo/vendor/xz2-0.1.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "xz2-0.1.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/xz2-0.1.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/yoke/yoke-0.8.0.crate",
         "sha256": "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc",
-        "dest": "cargo/vendor/yoke-0.8.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "yoke-0.8.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/yoke-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/yoke-derive/yoke-derive-0.8.0.crate",
         "sha256": "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6",
-        "dest": "cargo/vendor/yoke-derive-0.8.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "yoke-derive-0.8.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2238da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/yoke-derive-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zbus/zbus-5.7.1.crate",
-        "sha256": "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68",
-        "dest": "cargo/vendor/zbus-5.7.1"
+        "type": "file",
+        "url": "https://static.crates.io/crates/zbus/zbus-5.8.0.crate",
+        "sha256": "597f45e98bc7e6f0988276012797855613cd8269e23b5be62cc4e5d28b7e515d",
+        "dest": "cargo/vendor",
+        "dest-filename": "zbus-5.8.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68\", \"files\": {}}",
-        "dest": "cargo/vendor/zbus-5.7.1",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22597f45e98bc7e6f0988276012797855613cd8269e23b5be62cc4e5d28b7e515d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/zbus-5.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zbus_macros/zbus_macros-5.7.1.crate",
-        "sha256": "a17e7e5eec1550f747e71a058df81a9a83813ba0f6a95f39c4e218bdc7ba366a",
-        "dest": "cargo/vendor/zbus_macros-5.7.1"
+        "type": "file",
+        "url": "https://static.crates.io/crates/zbus_macros/zbus_macros-5.8.0.crate",
+        "sha256": "e5c8e4e14dcdd9d97a98b189cd1220f30e8394ad271e8c987da84f73693862c2",
+        "dest": "cargo/vendor",
+        "dest-filename": "zbus_macros-5.8.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"a17e7e5eec1550f747e71a058df81a9a83813ba0f6a95f39c4e218bdc7ba366a\", \"files\": {}}",
-        "dest": "cargo/vendor/zbus_macros-5.7.1",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e5c8e4e14dcdd9d97a98b189cd1220f30e8394ad271e8c987da84f73693862c2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/zbus_macros-5.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zbus_names/zbus_names-4.2.0.crate",
         "sha256": "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97",
-        "dest": "cargo/vendor/zbus_names-4.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "zbus_names-4.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%227be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zbus_names-4.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.8.26.crate",
         "sha256": "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f",
-        "dest": "cargo/vendor/zerocopy-0.8.26"
+        "dest": "cargo/vendor",
+        "dest-filename": "zerocopy-0.8.26.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%221039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zerocopy-0.8.26",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.8.26.crate",
         "sha256": "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181",
-        "dest": "cargo/vendor/zerocopy-derive-0.8.26"
+        "dest": "cargo/vendor",
+        "dest-filename": "zerocopy-derive-0.8.26.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%229ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zerocopy-derive-0.8.26",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zerofrom/zerofrom-0.1.6.crate",
         "sha256": "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5",
-        "dest": "cargo/vendor/zerofrom-0.1.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "zerofrom-0.1.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2250cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zerofrom-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zerofrom-derive/zerofrom-derive-0.1.6.crate",
         "sha256": "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502",
-        "dest": "cargo/vendor/zerofrom-derive-0.1.6"
+        "dest": "cargo/vendor",
+        "dest-filename": "zerofrom-derive-0.1.6.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zerofrom-derive-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zeroize/zeroize-1.8.1.crate",
         "sha256": "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde",
-        "dest": "cargo/vendor/zeroize-1.8.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "zeroize-1.8.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zeroize-1.8.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zeroize_derive/zeroize_derive-1.4.2.crate",
         "sha256": "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69",
-        "dest": "cargo/vendor/zeroize_derive-1.4.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "zeroize_derive-1.4.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zeroize_derive-1.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zerotrie/zerotrie-0.2.2.crate",
         "sha256": "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595",
-        "dest": "cargo/vendor/zerotrie-0.2.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "zerotrie-0.2.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2236f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zerotrie-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zerovec/zerovec-0.11.2.crate",
         "sha256": "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428",
-        "dest": "cargo/vendor/zerovec-0.11.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "zerovec-0.11.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%224a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zerovec-0.11.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zerovec-derive/zerovec-derive-0.11.1.crate",
         "sha256": "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f",
-        "dest": "cargo/vendor/zerovec-derive-0.11.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "zerovec-derive-0.11.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%225b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zerovec-derive-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zip/zip-3.0.0.crate",
         "sha256": "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308",
-        "dest": "cargo/vendor/zip-3.0.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "zip-3.0.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%2212598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zip-3.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zlib-rs/zlib-rs-0.5.1.crate",
         "sha256": "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a",
-        "dest": "cargo/vendor/zlib-rs-0.5.1"
+        "dest": "cargo/vendor",
+        "dest-filename": "zlib-rs-0.5.1.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zlib-rs-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zopfli/zopfli-0.8.2.crate",
         "sha256": "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7",
-        "dest": "cargo/vendor/zopfli-0.8.2"
+        "dest": "cargo/vendor",
+        "dest-filename": "zopfli-0.8.2.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zopfli-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zstd/zstd-0.13.3.crate",
         "sha256": "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a",
-        "dest": "cargo/vendor/zstd-0.13.3"
+        "dest": "cargo/vendor",
+        "dest-filename": "zstd-0.13.3.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zstd-0.13.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zstd-safe/zstd-safe-7.2.4.crate",
         "sha256": "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d",
-        "dest": "cargo/vendor/zstd-safe-7.2.4"
+        "dest": "cargo/vendor",
+        "dest-filename": "zstd-safe-7.2.4.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%228f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zstd-safe-7.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zstd-sys/zstd-sys-2.0.15+zstd.1.5.7.crate",
         "sha256": "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237",
-        "dest": "cargo/vendor/zstd-sys-2.0.15+zstd.1.5.7"
+        "dest": "cargo/vendor",
+        "dest-filename": "zstd-sys-2.0.15+zstd.1.5.7.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zstd-sys-2.0.15+zstd.1.5.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zvariant/zvariant-5.5.3.crate",
-        "sha256": "9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1",
-        "dest": "cargo/vendor/zvariant-5.5.3"
+        "type": "file",
+        "url": "https://static.crates.io/crates/zvariant/zvariant-5.6.0.crate",
+        "sha256": "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f",
+        "dest": "cargo/vendor",
+        "dest-filename": "zvariant-5.6.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1\", \"files\": {}}",
-        "dest": "cargo/vendor/zvariant-5.5.3",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/zvariant-5.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-5.5.3.crate",
-        "sha256": "75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580",
-        "dest": "cargo/vendor/zvariant_derive-5.5.3"
+        "type": "file",
+        "url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-5.6.0.crate",
+        "sha256": "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208",
+        "dest": "cargo/vendor",
+        "dest-filename": "zvariant_derive-5.6.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580\", \"files\": {}}",
-        "dest": "cargo/vendor/zvariant_derive-5.5.3",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%223a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "dest": "cargo/vendor/zvariant_derive-5.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "archive",
-        "archive-type": "tar-gzip",
+        "type": "file",
         "url": "https://static.crates.io/crates/zvariant_utils/zvariant_utils-3.2.0.crate",
         "sha256": "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34",
-        "dest": "cargo/vendor/zvariant_utils-3.2.0"
+        "dest": "cargo/vendor",
+        "dest-filename": "zvariant_utils-3.2.0.crate"
     },
     {
-        "type": "inline",
-        "contents": "{\"package\": \"e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34\", \"files\": {}}",
+        "type": "file",
+        "url": "data:%7B%22package%22%3A%20%22e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34%22%2C%20%22files%22%3A%20%7B%7D%7D",
         "dest": "cargo/vendor/zvariant_utils-3.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "inline",
-        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/an-anime-team/anime-game-core\"]\ngit = \"https://github.com/an-anime-team/anime-game-core\"\nreplace-with = \"vendored-sources\"\ntag = \"1.32.2\"\n\n[source.\"https://github.com/an-anime-team/anime-launcher-sdk\"]\ngit = \"https://github.com/an-anime-team/anime-launcher-sdk\"\nreplace-with = \"vendored-sources\"\ntag = \"1.28.7\"\n",
+        "type": "shell",
+        "dest": "cargo/vendor",
+        "commands": [
+            "for c in *.crate; do tar -xf $c; done"
+        ]
+    },
+    {
+        "type": "file",
+        "url": "data:%5Bsource.vendored-sources%5D%0Adirectory%20%3D%20%22cargo/vendor%22%0A%0A%5Bsource.crates-io%5D%0Areplace-with%20%3D%20%22vendored-sources%22%0A%0A%5Bsource.%22https%3A//github.com/an-anime-team/anime-game-core%22%5D%0Agit%20%3D%20%22https%3A//github.com/an-anime-team/anime-game-core%22%0Areplace-with%20%3D%20%22vendored-sources%22%0Atag%20%3D%20%221.33.1%22%0A%0A%5Bsource.%22https%3A//github.com/an-anime-team/anime-launcher-sdk%22%5D%0Agit%20%3D%20%22https%3A//github.com/an-anime-team/anime-launcher-sdk%22%0Areplace-with%20%3D%20%22vendored-sources%22%0Atag%20%3D%20%221.29.0%22%0A",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/moe.launcher.an-anime-game-launcher.metainfo.xml
+++ b/moe.launcher.an-anime-game-launcher.metainfo.xml
@@ -56,6 +56,20 @@
     <content_attribute id="money-gambling">moderate</content_attribute>
   </content_rating>
   <releases>
+   <release version="3.15.0" date="2025-07-11">
+     <description>
+       <p>Improved sophon implementation to utilize multiple threads</p>
+     </description>
+   </release>
+  <releases>
+   <release version="3.14.3" date="2025-06-21">
+     <description>
+       <p>Added 5.7.0 voiceover sizes</p>
+       <p>Added logic to get voiceover sizes from the API for the currently live version</p>
+       <p>Fixed crashes on game predownloading attempt</p>
+     </description>
+   </release>
+  <releases>
    <release version="3.14.2" date="2025-06-16">
      <description>
        <p>Added new game repairing support</p>

--- a/moe.launcher.an-anime-game-launcher.yml
+++ b/moe.launcher.an-anime-game-launcher.yml
@@ -171,7 +171,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/an-anime-team/an-anime-game-launcher
-        tag: &aagl_tag 3.14.3
+        tag: &aagl_tag 3.15.0
       - type: file
         path: moe.launcher.an-anime-game-launcher.sh
       - cargo-sources.json


### PR DESCRIPTION
- Update to 3.15.0
- Update metainfo + missing 3.14.3 info
- Back to generating cargo-sources with the submodules' `flatpak-cargo-generator`